### PR TITLE
fix: handle null categories to prevent TypeError when no categories e…

### DIFF
--- a/BackEnd/internal/services/category/categoryServices.go
+++ b/BackEnd/internal/services/category/categoryServices.go
@@ -42,7 +42,7 @@ func (c *CategoryServices) FindAll(ctx context.Context, userId string) ([]*dto.C
 	if err != nil {
 		return nil, err
 	}
-	var categoryResponseList []*dto.CategoryResponse
+	categoryResponseList := make([]*dto.CategoryResponse, 0)
 	for _, category := range categorysList {
 		categoryResonse := dto.NewCategoryResponse(category.Id, category.Name, category.Icon, category.Color, category.CreatedAt)
 		categoryResponseList = append(categoryResponseList, categoryResonse)

--- a/FrontendNextjs/gestor/app/repository/categoryRepository.ts
+++ b/FrontendNextjs/gestor/app/repository/categoryRepository.ts
@@ -5,7 +5,7 @@ export class CategoryRepository extends BaseRepository {
   async findAll(): Promise<Category[]> {
     try {
       const categories = await this.get<Category[]>("/category");
-      return categories;
+      return categories ?? [];
     } catch (error) {
       console.error("Error fetching categories:", error);
       return [];

--- a/FrontendNextjs/gestor/components/categories/CategoryList.tsx
+++ b/FrontendNextjs/gestor/components/categories/CategoryList.tsx
@@ -15,8 +15,10 @@ import { CategorySummaryCard } from './CategorySummaryCard'
 
 export function CategoryList() {
     const t = useTranslations('categories')
-    const { data: categories = [], isLoading: isLoadingCategories } = useGetCategories()
-    const { data: transactions = [], isLoading: isLoadingTransactions } = useGetAllTransactions()
+    const { data: categoriesData, isLoading: isLoadingCategories } = useGetCategories()
+    const { data: transactionsData, isLoading: isLoadingTransactions } = useGetAllTransactions()
+    const categories = categoriesData ?? []
+    const transactions = transactionsData ?? []
     const { setEditingCategory, setModalOpen } = useCategoryContext()
 
     const deleteCategoryMutation = useDeleteCategoryMutation()

--- a/FrontendNextjs/gestor/components/categories/CategorySummaryCard.tsx
+++ b/FrontendNextjs/gestor/components/categories/CategorySummaryCard.tsx
@@ -9,10 +9,12 @@ import { Transaction } from '@/types/transaction'
 
 export function CategorySummaryCard({ categories, transactions }: { categories: Category[], transactions: Transaction[] }) {
     const t = useTranslations('categories')
-    const activeCategories = categories.filter(cat =>
-        transactions.some(t => t.category_id === cat.id)
+    const safeCategories = categories ?? []
+    const safeTransactions = transactions ?? []
+    const activeCategories = safeCategories.filter(cat =>
+        safeTransactions.some(t => t.category_id === cat.id)
     )
-    const totalTransactions = transactions.length
+    const totalTransactions = safeTransactions.length
     const averagePerCategory = activeCategories.length > 0 ? Math.round(totalTransactions / activeCategories.length) : 0
 
     return (
@@ -29,7 +31,7 @@ export function CategorySummaryCard({ categories, transactions }: { categories: 
                         <Tag className="h-6 w-6 mx-auto mb-2 text-blue-600 dark:text-blue-400" />
                         <p className="text-sm font-medium text-muted-foreground">{t('totalCategories')}</p>
                         <p className="text-2xl font-bold text-foreground">
-                            <AnimatedCounter value={categories.length} />
+                            <AnimatedCounter value={safeCategories.length} />
                         </p>
                     </div>
                     <div className="text-center p-4 rounded-lg bg-gradient-to-br from-green-500/10 to-emerald-500/10 dark:from-green-500/5 dark:to-emerald-500/5">


### PR DESCRIPTION
…xist

Backend:
- Initialize categoryResponseList with make() instead of nil declaration
- Ensures JSON serialization returns [] instead of null when empty

Frontend:
- Add nullish coalescing (?? []) in categoryRepository.findAll()
- Add defensive validation in CategorySummaryCard component
- Replace default destructuring with explicit nullish coalescing in CategoryList

This fixes the production error:
TypeError: Cannot read properties of null (reading 'length')