### PR TITLE
fix(frontend): resolve theme persistence issue by removing invalid la…

### DIFF
--- a/FrontendNextjs/gestor/app/login/layout.tsx
+++ b/FrontendNextjs/gestor/app/login/layout.tsx
@@ -1,10 +1,5 @@
 import type { Metadata } from 'next'
-import { Inter } from 'next/font/google'
 import '../../styles/globals.css'
-import { ThemeProvider } from '@/components/common/theme-provider'
-import { cn } from '@/lib/utils'
-
-const inter = Inter({ subsets: ['latin'] })
 
 export const metadata: Metadata = {
 	title: 'Iniciar Sesión - FinanceApp',
@@ -17,17 +12,8 @@ export default function LoginLayout({
 	children: React.ReactNode
 }) {
 	return (
-		<html lang="es">
-			<body className={cn(inter.className, 'antialiased')}>
-				<ThemeProvider
-					attribute="class"
-					defaultTheme="system"
-					enableSystem
-					disableTransitionOnChange
-				>
-					{children}
-				</ThemeProvider>
-			</body>
-		</html>
+		<>
+			{children}
+		</>
 	)
 }

--- a/FrontendNextjs/gestor/app/register/layout.tsx
+++ b/FrontendNextjs/gestor/app/register/layout.tsx
@@ -1,10 +1,5 @@
 import type { Metadata } from 'next'
-import { Inter } from 'next/font/google'
 import '../../styles/globals.css'
-import { ThemeProvider } from '@/components/common/theme-provider'
-import { cn } from '@/lib/utils'
-
-const inter = Inter({ subsets: ['latin'] })
 
 export const metadata: Metadata = {
 	title: 'Crear Cuenta - FinanceApp',
@@ -17,17 +12,8 @@ export default function RegisterLayout({
 	children: React.ReactNode
 }) {
 	return (
-		<html lang="es">
-			<body className={cn(inter.className, 'antialiased')}>
-				<ThemeProvider
-					attribute="class"
-					defaultTheme="system"
-					enableSystem
-					disableTransitionOnChange
-				>
-					{children}
-				</ThemeProvider>
-			</body>
-		</html>
+		<>
+			{children}
+		</>
 	)
 }

--- a/FrontendNextjs/gestor/contexts/settings-context.tsx
+++ b/FrontendNextjs/gestor/contexts/settings-context.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { createContext, useContext, useState, useEffect, ReactNode } from 'react'
+import { useTheme } from 'next-themes'
 
 interface SettingsContextType {
 	sidebarHoverEnabled: boolean
@@ -49,7 +50,15 @@ interface SettingsProviderProps {
 export const SettingsProvider = ({ children }: SettingsProviderProps) => {
 	// Initialize with default values
 	const [sidebarHoverEnabled, setSidebarHoverEnabled] = useState(defaultSettings.sidebarHoverEnabled)
-	const [theme, setTheme] = useState<'light' | 'dark' | 'system'>(defaultSettings.theme)
+	
+	// Use next-themes for theme management
+	const { theme: nextTheme, setTheme: setNextTheme } = useTheme()
+	
+	// Adapt next-themes to our context type
+	// If nextTheme is undefined (during SSR or initial mount), fallback to default
+	const theme = (nextTheme as 'light' | 'dark' | 'system') || defaultSettings.theme
+	const setTheme = (t: 'light' | 'dark' | 'system') => setNextTheme(t)
+
 	const [language, setLanguage] = useState<'es' | 'en'>(defaultSettings.language)
 	const [currency, setCurrency] = useState<'USD' | 'EUR' | 'MXN'>(defaultSettings.currency)
 	const [notifications, setNotifications] = useState(defaultSettings.notifications)
@@ -64,7 +73,8 @@ export const SettingsProvider = ({ children }: SettingsProviderProps) => {
 				const parsed = JSON.parse(savedSettings)
 				
 				setSidebarHoverEnabled(parsed.sidebarHoverEnabled ?? defaultSettings.sidebarHoverEnabled)
-				setTheme(parsed.theme ?? defaultSettings.theme)
+				// We don't set theme here because next-themes handles it independently
+				// and is the source of truth based on its own storage/detection
 				setLanguage(parsed.language ?? defaultSettings.language)
 				setCurrency(parsed.currency ?? defaultSettings.currency)
 				setNotifications(parsed.notifications ?? defaultSettings.notifications)
@@ -81,7 +91,7 @@ export const SettingsProvider = ({ children }: SettingsProviderProps) => {
 		try {
 			const settings = {
 				sidebarHoverEnabled,
-				theme,
+				theme, // Save current theme to app-settings for consistency/backup
 				language,
 				currency,
 				notifications


### PR DESCRIPTION
…yout nesting and unifying SettingsContext with next-themes

- Remove duplicate <html>, <body>, and ThemeProvider from login and register layouts to fix invalid DOM nesting.
- Refactor SettingsContext to use useTheme from next-themes as the source of truth for theme state, ensuring synchronization during navigation.
- Fix issue where dark mode was lost on client-side navigation from login to dashboard.