### PR TITLE
fix(backend): migrate JWT library from v3 to v5 for security

### DIFF
--- a/BackEnd/go.mod
+++ b/BackEnd/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.4
 require (
 	github.com/go-faker/faker/v4 v4.2.0
 	github.com/go-playground/assert/v2 v2.2.0
-	github.com/golang-jwt/jwt v3.2.2+incompatible
+	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/google/uuid v1.6.0
 	github.com/mattn/go-sqlite3 v1.14.28
 	github.com/patrickmn/go-cache v2.1.0+incompatible

--- a/BackEnd/go.sum
+++ b/BackEnd/go.sum
@@ -87,8 +87,8 @@ github.com/go-playground/validator/v10 v10.27.0/go.mod h1:I5QpIEbmr8On7W0TktmJAu
 github.com/goccy/go-json v0.10.5 h1:Fq85nIqj+gXn/S5ahsiTlK3TmC85qgirsdTP/+DeaC4=
 github.com/goccy/go-json v0.10.5/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
-github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
-github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
+github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
+github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang-migrate/migrate/v4 v4.17.1 h1:4zQ6iqL6t6AiItphxJctQb3cFqWiSpMnX7wLTPnnYO4=
 github.com/golang-migrate/migrate/v4 v4.17.1/go.mod h1:m8hinFyWBn0SA4QKHuKh175Pm9wjmxj3S2Mia7dbXzM=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=

--- a/BackEnd/internal/platform/server/middleware/auth.go
+++ b/BackEnd/internal/platform/server/middleware/auth.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
-	"github.com/golang-jwt/jwt"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/osmait/gestorDePresupuesto/internal/config"
 	dto "github.com/osmait/gestorDePresupuesto/internal/platform/dto/user"
 	"github.com/osmait/gestorDePresupuesto/internal/services/user"
@@ -43,7 +43,7 @@ func shouldCheckToken(route string) bool {
 // AppClaims represents the JWT claims structure
 type AppClaims struct {
 	UserId string `json:"id"`
-	jwt.StandardClaims
+	jwt.RegisteredClaims
 }
 
 // AuthMiddleware provides JWT-based authentication with configurable secret

--- a/BackEnd/internal/platform/utils/jwtCreate.go
+++ b/BackEnd/internal/platform/utils/jwtCreate.go
@@ -4,12 +4,13 @@ import (
 	"errors"
 	"time"
 
-	"github.com/golang-jwt/jwt"
+	"github.com/golang-jwt/jwt/v5"
 )
 
+// AppClaims represents the JWT claims structure with user-specific data
 type AppClaims struct {
 	UserId string `json:"id"`
-	jwt.StandardClaims
+	jwt.RegisteredClaims
 }
 
 // JwtCreate creates a JWT token with the provided secret
@@ -24,8 +25,10 @@ func JwtCreate(id string, secret string) (*string, error) {
 
 	claims := AppClaims{
 		UserId: id,
-		StandardClaims: jwt.StandardClaims{
-			ExpiresAt: time.Now().Add(time.Hour * 72).Unix(),
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour * 72)),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			NotBefore: jwt.NewNumericDate(time.Now()),
 		},
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)

--- a/BackEnd/internal/platform/utils/jwt_test.go
+++ b/BackEnd/internal/platform/utils/jwt_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang-jwt/jwt"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -100,7 +100,7 @@ func TestJwtCreate_TokenExpiration(t *testing.T) {
 
 	// Check that expiration is set to approximately 72 hours from now
 	expectedExpiration := time.Now().Add(time.Hour * 72).Unix()
-	actualExpiration := claims.ExpiresAt
+	actualExpiration := claims.ExpiresAt.Unix()
 
 	// Allow 60 second tolerance for test execution time
 	assert.InDelta(t, expectedExpiration, actualExpiration, 60, "Expiration should be approximately 72 hours from now")
@@ -176,11 +176,11 @@ func TestJwtCreate_DifferentSecrets(t *testing.T) {
 func TestAppClaims_Structure(t *testing.T) {
 	claims := AppClaims{
 		UserId: "test_user_123",
-		StandardClaims: jwt.StandardClaims{
-			ExpiresAt: time.Now().Add(time.Hour).Unix(),
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
 		},
 	}
 
 	assert.Equal(t, "test_user_123", claims.UserId)
-	assert.Greater(t, claims.ExpiresAt, time.Now().Unix())
+	assert.Greater(t, claims.ExpiresAt.Unix(), time.Now().Unix())
 }


### PR DESCRIPTION
- Upgrade github.com/golang-jwt/jwt from v3.2.2 to v5.2.1
- Replace deprecated StandardClaims with RegisteredClaims
- Use jwt.NewNumericDate() for ExpiresAt, IssuedAt, NotBefore
- Update auth middleware and JWT utility to use v5 API
- Update tests to use new RegisteredClaims structure

BREAKING CHANGE: JWT tokens now use RegisteredClaims format