### PR TITLE
feat(certificates): support editing recorded payments

### DIFF
--- a/BackEnd/cmd/api/db/migrations/000031_add_updated_at_to_certificate_payments.down.sql
+++ b/BackEnd/cmd/api/db/migrations/000031_add_updated_at_to_certificate_payments.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE certificate_payments DROP COLUMN updated_at;

--- a/BackEnd/cmd/api/db/migrations/000031_add_updated_at_to_certificate_payments.up.sql
+++ b/BackEnd/cmd/api/db/migrations/000031_add_updated_at_to_certificate_payments.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE certificate_payments ADD COLUMN updated_at TIMESTAMPTZ;
+UPDATE certificate_payments SET updated_at = created_at WHERE updated_at IS NULL;

--- a/BackEnd/internal/domain/certificate/certificate_payment.go
+++ b/BackEnd/internal/domain/certificate/certificate_payment.go
@@ -18,6 +18,7 @@ type CertificatePayment struct {
 	PayoutAccountId *string
 	TransactionId   *string
 	CreatedAt       time.Time
+	UpdatedAt       *time.Time
 }
 
 func NewCertificatePayment(id, certificateId, userId string, paymentDate, periodStart, periodEnd time.Time, gross, tax, net, rate, taxRate, capital float64) *CertificatePayment {

--- a/BackEnd/internal/platform/dto/certificate/certificateRequest.go
+++ b/BackEnd/internal/platform/dto/certificate/certificateRequest.go
@@ -62,6 +62,18 @@ type UpdateCertificateRequest struct {
 	Status              *certificate.CertificateStatus `json:"status" binding:"omitempty,oneof=active matured cancelled"`
 }
 
+type UpdateCertificatePaymentRequest struct {
+	PaymentDate    *string  `json:"payment_date"`
+	PeriodStart    *string  `json:"period_start"`
+	PeriodEnd      *string  `json:"period_end"`
+	GrossInterest  *float64 `json:"gross_interest" binding:"omitempty,gte=0"`
+	TaxWithheld    *float64 `json:"tax_withheld" binding:"omitempty,gte=0"`
+	NetInterest    *float64 `json:"net_interest" binding:"omitempty,gte=0"`
+	AppliedRate    *float64 `json:"applied_rate" binding:"omitempty,gt=0,lte=100"`
+	AppliedTaxRate *float64 `json:"applied_tax_rate" binding:"omitempty,gte=0,lte=100"`
+	AppliedCapital *float64 `json:"applied_capital" binding:"omitempty,gt=0"`
+}
+
 type SimulatePaymentRequest struct {
 	Capital *float64 `json:"capital" binding:"omitempty,gt=0"`
 	Rate    *float64 `json:"rate" binding:"omitempty,gt=0,lte=100"`

--- a/BackEnd/internal/platform/dto/certificate/certificateResponse.go
+++ b/BackEnd/internal/platform/dto/certificate/certificateResponse.go
@@ -48,11 +48,11 @@ type CertificateWithHistoryResponse struct {
 }
 
 type PaymentResponse struct {
-	Id             string    `json:"id"`
+	Id             string     `json:"id"`
 	CertificateId  string    `json:"certificate_id"`
-	PaymentDate    time.Time `json:"payment_date"`
-	PeriodStart    time.Time `json:"period_start"`
-	PeriodEnd      time.Time `json:"period_end"`
+	PaymentDate    time.Time  `json:"payment_date"`
+	PeriodStart    time.Time  `json:"period_start"`
+	PeriodEnd      time.Time  `json:"period_end"`
 	GrossInterest  float64   `json:"gross_interest"`
 	TaxWithheld    float64   `json:"tax_withheld"`
 	NetInterest    float64   `json:"net_interest"`
@@ -60,7 +60,8 @@ type PaymentResponse struct {
 	AppliedTaxRate float64   `json:"applied_tax_rate"`
 	AppliedCapital float64   `json:"applied_capital"`
 	TransactionId  *string   `json:"transaction_id"`
-	CreatedAt      time.Time `json:"created_at"`
+	CreatedAt      time.Time  `json:"created_at"`
+	UpdatedAt      *time.Time `json:"updated_at"`
 }
 
 type SimulationResponse struct {
@@ -111,5 +112,6 @@ func NewPaymentResponse(payment *certificate.CertificatePayment) *PaymentRespons
 		AppliedCapital: payment.AppliedCapital,
 		TransactionId:  payment.TransactionId,
 		CreatedAt:      payment.CreatedAt,
+		UpdatedAt:      payment.UpdatedAt,
 	}
 }

--- a/BackEnd/internal/platform/server/handler/certificate/certificateHandler.go
+++ b/BackEnd/internal/platform/server/handler/certificate/certificateHandler.go
@@ -112,6 +112,26 @@ func SimulateCertificate(certificateService *certificate.CertificateService) gin
 	}
 }
 
+func UpdateCertificatePayment(certificateService *certificate.CertificateService) gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		userId := ctx.GetString("X-User-Id")
+		paymentId := ctx.Param("paymentId")
+
+		var req dto.UpdateCertificatePaymentRequest
+		if err := ctx.BindJSON(&req); err != nil {
+			_ = ctx.Error(apperrors.NewValidationError("INVALID_JSON", "Invalid request body"))
+			return
+		}
+
+		err := certificateService.UpdatePayment(ctx, paymentId, &req, userId)
+		if err != nil {
+			_ = ctx.Error(err)
+			return
+		}
+		ctx.JSON(http.StatusOK, gin.H{"message": "Payment updated successfully"})
+	}
+}
+
 func GetCertificateSummary(certificateService *certificate.CertificateService) gin.HandlerFunc {
 	return func(ctx *gin.Context) {
 		userId := ctx.GetString("X-User-Id")

--- a/BackEnd/internal/platform/server/routes/certificateRoutes.go
+++ b/BackEnd/internal/platform/server/routes/certificateRoutes.go
@@ -18,6 +18,7 @@ func CertificateRoutes(s *gin.Engine, certificateService *certificate.Certificat
 		certGroup.GET("/:id", handler.FindCertificateById(certificateService))
 		certGroup.PUT("/:id", handler.UpdateCertificate(certificateService))
 		certGroup.DELETE("/:id", handler.DeleteCertificate(certificateService))
+		certGroup.PUT("/payments/:paymentId", handler.UpdateCertificatePayment(certificateService))
 		certGroup.POST("/:id/simulate", handler.SimulateCertificate(certificateService))
 	}
 }

--- a/BackEnd/internal/platform/storage/postgress/certificate/certificateRepoInterface.go
+++ b/BackEnd/internal/platform/storage/postgress/certificate/certificateRepoInterface.go
@@ -19,5 +19,7 @@ type CertificateRepositoryInterface interface {
 	FindPaymentsByCertificate(ctx context.Context, certificateId string) ([]*certificate.CertificatePayment, error)
 	FindLastPayment(ctx context.Context, certificateId string) (*certificate.CertificatePayment, error)
 	FindAllPayments(ctx context.Context, userId string) ([]*certificate.CertificatePayment, error)
+	FindPaymentById(ctx context.Context, paymentId string, userId string) (*certificate.CertificatePayment, error)
+	UpdatePayment(ctx context.Context, payment *certificate.CertificatePayment) error
 	UpdatePaymentTransaction(ctx context.Context, paymentId string, transactionId string) error
 }

--- a/BackEnd/internal/platform/storage/postgress/certificate/certificateRepository.go
+++ b/BackEnd/internal/platform/storage/postgress/certificate/certificateRepository.go
@@ -165,7 +165,7 @@ func (r *CertificateRepository) SavePayment(ctx context.Context, payment *certif
 
 func (r *CertificateRepository) FindPaymentsByCertificate(ctx context.Context, certificateId string) ([]*certificate.CertificatePayment, error) {
 	query := `SELECT id, certificate_id, user_id, payment_date, period_start, period_end, gross_interest, tax_withheld,
-		net_interest, applied_rate, applied_tax_rate, applied_capital, payout_account_id, transaction_id, created_at
+		net_interest, applied_rate, applied_tax_rate, applied_capital, payout_account_id, transaction_id, created_at, updated_at
 		FROM certificate_payments WHERE certificate_id = $1 ORDER BY payment_date DESC`
 	rows, err := r.db.QueryContext(ctx, query, certificateId)
 	if err != nil {
@@ -182,7 +182,7 @@ func (r *CertificateRepository) FindPaymentsByCertificate(ctx context.Context, c
 		p := &certificate.CertificatePayment{}
 		if err = rows.Scan(&p.Id, &p.CertificateId, &p.UserId, &p.PaymentDate, &p.PeriodStart, &p.PeriodEnd,
 			&p.GrossInterest, &p.TaxWithheld, &p.NetInterest, &p.AppliedRate, &p.AppliedTaxRate,
-			&p.AppliedCapital, &p.PayoutAccountId, &p.TransactionId, &p.CreatedAt); err == nil {
+			&p.AppliedCapital, &p.PayoutAccountId, &p.TransactionId, &p.CreatedAt, &p.UpdatedAt); err == nil {
 			payments = append(payments, p)
 		}
 	}
@@ -194,14 +194,14 @@ func (r *CertificateRepository) FindPaymentsByCertificate(ctx context.Context, c
 
 func (r *CertificateRepository) FindLastPayment(ctx context.Context, certificateId string) (*certificate.CertificatePayment, error) {
 	query := `SELECT id, certificate_id, user_id, payment_date, period_start, period_end, gross_interest, tax_withheld,
-		net_interest, applied_rate, applied_tax_rate, applied_capital, payout_account_id, transaction_id, created_at
+		net_interest, applied_rate, applied_tax_rate, applied_capital, payout_account_id, transaction_id, created_at, updated_at
 		FROM certificate_payments WHERE certificate_id = $1 ORDER BY payment_date DESC LIMIT 1`
 	row := r.db.QueryRowContext(ctx, query, certificateId)
 
 	p := &certificate.CertificatePayment{}
 	err := row.Scan(&p.Id, &p.CertificateId, &p.UserId, &p.PaymentDate, &p.PeriodStart, &p.PeriodEnd,
 		&p.GrossInterest, &p.TaxWithheld, &p.NetInterest, &p.AppliedRate, &p.AppliedTaxRate,
-		&p.AppliedCapital, &p.PayoutAccountId, &p.TransactionId, &p.CreatedAt)
+		&p.AppliedCapital, &p.PayoutAccountId, &p.TransactionId, &p.CreatedAt, &p.UpdatedAt)
 	if err != nil {
 		return nil, err
 	}
@@ -210,7 +210,7 @@ func (r *CertificateRepository) FindLastPayment(ctx context.Context, certificate
 
 func (r *CertificateRepository) FindAllPayments(ctx context.Context, userId string) ([]*certificate.CertificatePayment, error) {
 	query := `SELECT id, certificate_id, user_id, payment_date, period_start, period_end, gross_interest, tax_withheld,
-		net_interest, applied_rate, applied_tax_rate, applied_capital, payout_account_id, transaction_id, created_at
+		net_interest, applied_rate, applied_tax_rate, applied_capital, payout_account_id, transaction_id, created_at, updated_at
 		FROM certificate_payments WHERE user_id = $1 ORDER BY payment_date DESC`
 	rows, err := r.db.QueryContext(ctx, query, userId)
 	if err != nil {
@@ -227,7 +227,7 @@ func (r *CertificateRepository) FindAllPayments(ctx context.Context, userId stri
 		p := &certificate.CertificatePayment{}
 		if err = rows.Scan(&p.Id, &p.CertificateId, &p.UserId, &p.PaymentDate, &p.PeriodStart, &p.PeriodEnd,
 			&p.GrossInterest, &p.TaxWithheld, &p.NetInterest, &p.AppliedRate, &p.AppliedTaxRate,
-			&p.AppliedCapital, &p.PayoutAccountId, &p.TransactionId, &p.CreatedAt); err == nil {
+			&p.AppliedCapital, &p.PayoutAccountId, &p.TransactionId, &p.CreatedAt, &p.UpdatedAt); err == nil {
 			payments = append(payments, p)
 		}
 	}
@@ -235,6 +235,43 @@ func (r *CertificateRepository) FindAllPayments(ctx context.Context, userId stri
 		return nil, err
 	}
 	return payments, nil
+}
+
+func (r *CertificateRepository) FindPaymentById(ctx context.Context, paymentId string, userId string) (*certificate.CertificatePayment, error) {
+	query := `SELECT id, certificate_id, user_id, payment_date, period_start, period_end, gross_interest, tax_withheld,
+		net_interest, applied_rate, applied_tax_rate, applied_capital, payout_account_id, transaction_id, created_at, updated_at
+		FROM certificate_payments WHERE id = $1 AND user_id = $2`
+	row := r.db.QueryRowContext(ctx, query, paymentId, userId)
+
+	p := &certificate.CertificatePayment{}
+	err := row.Scan(&p.Id, &p.CertificateId, &p.UserId, &p.PaymentDate, &p.PeriodStart, &p.PeriodEnd,
+		&p.GrossInterest, &p.TaxWithheld, &p.NetInterest, &p.AppliedRate, &p.AppliedTaxRate,
+		&p.AppliedCapital, &p.PayoutAccountId, &p.TransactionId, &p.CreatedAt, &p.UpdatedAt)
+	if err != nil {
+		return nil, err
+	}
+	return p, nil
+}
+
+func (r *CertificateRepository) UpdatePayment(ctx context.Context, payment *certificate.CertificatePayment) error {
+	query := `UPDATE certificate_payments SET payment_date = $1, period_start = $2, period_end = $3,
+		gross_interest = $4, tax_withheld = $5, net_interest = $6, applied_rate = $7, applied_tax_rate = $8,
+		applied_capital = $9, updated_at = $10
+		WHERE id = $11 AND user_id = $12`
+	result, err := r.db.ExecContext(ctx, query, payment.PaymentDate, payment.PeriodStart, payment.PeriodEnd,
+		payment.GrossInterest, payment.TaxWithheld, payment.NetInterest, payment.AppliedRate, payment.AppliedTaxRate,
+		payment.AppliedCapital, payment.UpdatedAt, payment.Id, payment.UserId)
+	if err != nil {
+		return err
+	}
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rowsAffected == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
 }
 
 func (r *CertificateRepository) UpdatePaymentTransaction(ctx context.Context, paymentId string, transactionId string) error {

--- a/BackEnd/internal/services/certificate/certificateService.go
+++ b/BackEnd/internal/services/certificate/certificateService.go
@@ -216,6 +216,61 @@ func (s *CertificateService) UpdateCertificate(ctx context.Context, id string, r
 	return s.repository.Update(ctx, cert)
 }
 
+func (s *CertificateService) UpdatePayment(ctx context.Context, paymentId string, req *dto.UpdateCertificatePaymentRequest, userId string) error {
+	payment, err := s.repository.FindPaymentById(ctx, paymentId, userId)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return errors.New("payment not found")
+		}
+		return err
+	}
+
+	if req.PaymentDate != nil {
+		t, err := time.Parse("2006-01-02", *req.PaymentDate)
+		if err != nil {
+			return errors.New("invalid payment_date format, expected YYYY-MM-DD")
+		}
+		payment.PaymentDate = t
+	}
+	if req.PeriodStart != nil {
+		t, err := time.Parse("2006-01-02", *req.PeriodStart)
+		if err != nil {
+			return errors.New("invalid period_start format, expected YYYY-MM-DD")
+		}
+		payment.PeriodStart = t
+	}
+	if req.PeriodEnd != nil {
+		t, err := time.Parse("2006-01-02", *req.PeriodEnd)
+		if err != nil {
+			return errors.New("invalid period_end format, expected YYYY-MM-DD")
+		}
+		payment.PeriodEnd = t
+	}
+	if req.GrossInterest != nil {
+		payment.GrossInterest = *req.GrossInterest
+	}
+	if req.TaxWithheld != nil {
+		payment.TaxWithheld = *req.TaxWithheld
+	}
+	if req.NetInterest != nil {
+		payment.NetInterest = *req.NetInterest
+	}
+	if req.AppliedRate != nil {
+		payment.AppliedRate = *req.AppliedRate
+	}
+	if req.AppliedTaxRate != nil {
+		payment.AppliedTaxRate = *req.AppliedTaxRate
+	}
+	if req.AppliedCapital != nil {
+		payment.AppliedCapital = *req.AppliedCapital
+	}
+
+	now := time.Now()
+	payment.UpdatedAt = &now
+
+	return s.repository.UpdatePayment(ctx, payment)
+}
+
 func (s *CertificateService) DeleteCertificate(ctx context.Context, id string, userId string) error {
 	return s.repository.Delete(ctx, id, userId)
 }

--- a/BackEnd/internal/services/certificate/certificateService_test.go
+++ b/BackEnd/internal/services/certificate/certificateService_test.go
@@ -92,6 +92,19 @@ func (m *MockCertificateRepository) FindAllPayments(ctx context.Context, userId 
 	return args.Get(0).([]*certificate.CertificatePayment), args.Error(1)
 }
 
+func (m *MockCertificateRepository) FindPaymentById(ctx context.Context, paymentId string, userId string) (*certificate.CertificatePayment, error) {
+	args := m.Called(ctx, paymentId, userId)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*certificate.CertificatePayment), args.Error(1)
+}
+
+func (m *MockCertificateRepository) UpdatePayment(ctx context.Context, payment *certificate.CertificatePayment) error {
+	args := m.Called(ctx, payment)
+	return args.Error(0)
+}
+
 func (m *MockCertificateRepository) UpdatePaymentTransaction(ctx context.Context, paymentId string, transactionId string) error {
 	args := m.Called(ctx, paymentId, transactionId)
 	return args.Error(0)

--- a/FrontendNextjs/gestor/app/repository/certificateRepository.ts
+++ b/FrontendNextjs/gestor/app/repository/certificateRepository.ts
@@ -5,6 +5,7 @@ import {
 	CertificateSummary,
 	CreateCertificateDTO,
 	UpdateCertificateDTO,
+	UpdateCertificatePaymentDTO,
 	SimulatePaymentDTO,
 	SimulationResult,
 } from '@/types/certificate'
@@ -28,6 +29,10 @@ export class CertificateRepository extends BaseRepository {
 
 	async delete(id: string): Promise<void> {
 		return this.deleteRequest(`/certificate/${id}`)
+	}
+
+	async updatePayment(paymentId: string, data: UpdateCertificatePaymentDTO): Promise<void> {
+		return this.put(`/certificate/payments/${paymentId}`, data)
 	}
 
 	async simulate(id: string, data: SimulatePaymentDTO): Promise<SimulationResult> {

--- a/FrontendNextjs/gestor/components/certificates/CertificatePaymentHistory.tsx
+++ b/FrontendNextjs/gestor/components/certificates/CertificatePaymentHistory.tsx
@@ -1,18 +1,37 @@
 'use client'
 
 import { useState } from 'react'
-import { CertificateWithHistory, CertificatePayment, formatCurrency } from '@/types/certificate'
-import { useGetCertificate } from '@/hooks/queries/useCertificatesQuery'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import * as z from 'zod'
+import { Pencil } from 'lucide-react'
+import { CertificatePayment, formatCurrency } from '@/types/certificate'
+import { useGetCertificate, useUpdateCertificatePaymentMutation } from '@/hooks/queries/useCertificatesQuery'
 import {
 	Dialog,
 	DialogContent,
 	DialogHeader,
 	DialogTitle,
+	DialogFooter,
 } from '@/components/ui/dialog'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import { CertificateChart } from './CertificateChart'
+
+const editPaymentSchema = z.object({
+	gross_interest: z.coerce.number().min(0, 'Must be >= 0'),
+	tax_withheld: z.coerce.number().min(0, 'Must be >= 0'),
+	net_interest: z.coerce.number().min(0, 'Must be >= 0'),
+	applied_rate: z.coerce.number().min(0.01).max(100),
+	applied_tax_rate: z.coerce.number().min(0).max(100),
+	applied_capital: z.coerce.number().min(0.01, 'Must be > 0'),
+})
+
+type EditPaymentFormData = z.infer<typeof editPaymentSchema>
 
 interface CertificatePaymentHistoryProps {
 	certificateId: string | null
@@ -23,78 +42,179 @@ interface CertificatePaymentHistoryProps {
 export function CertificatePaymentHistory({ certificateId, open, onOpenChange }: CertificatePaymentHistoryProps) {
 	const { data: certificate, isLoading } = useGetCertificate(certificateId || '')
 	const payments = certificate?.payments ?? []
+	const [editingPayment, setEditingPayment] = useState<CertificatePayment | null>(null)
+	const updatePaymentMutation = useUpdateCertificatePaymentMutation()
+
+	const {
+		register,
+		handleSubmit,
+		reset,
+		formState: { errors },
+	} = useForm<EditPaymentFormData>({
+		resolver: zodResolver(editPaymentSchema),
+	})
+
+	function openEditDialog(payment: CertificatePayment) {
+		reset({
+			gross_interest: payment.gross_interest,
+			tax_withheld: payment.tax_withheld,
+			net_interest: payment.net_interest,
+			applied_rate: payment.applied_rate,
+			applied_tax_rate: payment.applied_tax_rate,
+			applied_capital: payment.applied_capital,
+		})
+		setEditingPayment(payment)
+	}
+
+	async function onEditSubmit(data: EditPaymentFormData) {
+		if (!editingPayment) return
+		await updatePaymentMutation.mutateAsync({
+			paymentId: editingPayment.id,
+			data: {
+				gross_interest: data.gross_interest,
+				tax_withheld: data.tax_withheld,
+				net_interest: data.net_interest,
+				applied_rate: data.applied_rate,
+				applied_tax_rate: data.applied_tax_rate,
+				applied_capital: data.applied_capital,
+			},
+		})
+		setEditingPayment(null)
+	}
 
 	if (!certificateId) return null
 
 	return (
-		<Dialog open={open} onOpenChange={onOpenChange}>
-			<DialogContent className="sm:max-w-[800px] max-h-[90vh] overflow-y-auto">
-				<DialogHeader>
-					<DialogTitle>Payment History - {certificate?.bank || 'Loading...'}</DialogTitle>
-				</DialogHeader>
-				{isLoading ? (
-					<div className="py-8 text-center text-muted-foreground">Loading...</div>
-				) : certificate ? (
-					<div className="space-y-4">
-						<div className="grid grid-cols-3 gap-4 p-4 rounded-lg bg-muted/50">
-							<div>
-								<p className="text-xs text-muted-foreground">Total Gross Interest</p>
-								<p className="text-lg font-semibold">{formatCurrency(certificate.summary?.total_gross_interest || 0)}</p>
+		<>
+			<Dialog open={open} onOpenChange={onOpenChange}>
+				<DialogContent className="sm:max-w-[800px] max-h-[90vh] overflow-y-auto">
+					<DialogHeader>
+						<DialogTitle>Payment History - {certificate?.bank || 'Loading...'}</DialogTitle>
+					</DialogHeader>
+					{isLoading ? (
+						<div className="py-8 text-center text-muted-foreground">Loading...</div>
+					) : certificate ? (
+						<div className="space-y-4">
+							<div className="grid grid-cols-3 gap-4 p-4 rounded-lg bg-muted/50">
+								<div>
+									<p className="text-xs text-muted-foreground">Total Gross Interest</p>
+									<p className="text-lg font-semibold">{formatCurrency(certificate.summary?.total_gross_interest || 0)}</p>
+								</div>
+								<div>
+									<p className="text-xs text-muted-foreground">Total Tax Withheld</p>
+									<p className="text-lg font-semibold text-orange-500">{formatCurrency(certificate.summary?.total_tax_withheld || 0)}</p>
+								</div>
+								<div>
+									<p className="text-xs text-muted-foreground">Total Net Interest</p>
+									<p className="text-lg font-semibold text-green-500">{formatCurrency(certificate.summary?.total_net_interest || 0)}</p>
+								</div>
 							</div>
-							<div>
-								<p className="text-xs text-muted-foreground">Total Tax Withheld</p>
-								<p className="text-lg font-semibold text-orange-500">{formatCurrency(certificate.summary?.total_tax_withheld || 0)}</p>
+
+							<Tabs defaultValue="history">
+								<TabsList className="grid w-full grid-cols-2">
+									<TabsTrigger value="history">History</TabsTrigger>
+									<TabsTrigger value="chart">Chart</TabsTrigger>
+								</TabsList>
+								<TabsContent value="history" className="mt-4">
+									{payments.length === 0 ? (
+										<div className="py-8 text-center text-muted-foreground">No payments recorded yet.</div>
+									) : (
+										<ScrollArea className="h-[400px]">
+											<Table>
+												<TableHeader>
+													<TableRow>
+														<TableHead>Date</TableHead>
+														<TableHead className="text-right">Capital</TableHead>
+														<TableHead className="text-right">Rate</TableHead>
+														<TableHead className="text-right">Gross</TableHead>
+														<TableHead className="text-right">Tax</TableHead>
+														<TableHead className="text-right">Net</TableHead>
+														<TableHead className="w-[50px]">Actions</TableHead>
+													</TableRow>
+												</TableHeader>
+												<TableBody>
+													{payments.map((payment) => (
+														<TableRow key={payment.id}>
+															<TableCell>{new Date(payment.payment_date).toLocaleDateString()}</TableCell>
+															<TableCell className="text-right">{formatCurrency(payment.applied_capital)}</TableCell>
+															<TableCell className="text-right">{payment.applied_rate}%</TableCell>
+															<TableCell className="text-right">{formatCurrency(payment.gross_interest)}</TableCell>
+															<TableCell className="text-right text-orange-500">-{formatCurrency(payment.tax_withheld)}</TableCell>
+															<TableCell className="text-right text-green-500 font-medium">{formatCurrency(payment.net_interest)}</TableCell>
+															<TableCell>
+																<Button
+																	variant="ghost"
+																	size="icon"
+																	className="h-7 w-7"
+																	onClick={() => openEditDialog(payment)}
+																	aria-label="Edit payment"
+																>
+																	<Pencil className="h-4 w-4" />
+																</Button>
+															</TableCell>
+														</TableRow>
+													))}
+												</TableBody>
+											</Table>
+										</ScrollArea>
+									)}
+								</TabsContent>
+								<TabsContent value="chart" className="mt-4">
+									<CertificateChart certificate={certificate} payments={payments} />
+								</TabsContent>
+							</Tabs>
+						</div>
+					) : null}
+				</DialogContent>
+			</Dialog>
+
+			<Dialog open={!!editingPayment} onOpenChange={(open) => { if (!open) setEditingPayment(null) }}>
+				<DialogContent className="sm:max-w-[450px]">
+					<DialogHeader>
+						<DialogTitle>Edit Payment</DialogTitle>
+					</DialogHeader>
+					<form onSubmit={handleSubmit(onEditSubmit)} className="space-y-4">
+						<div className="grid gap-4 py-4">
+							<div className="grid grid-cols-4 items-center gap-4">
+								<Label htmlFor="edit_gross_interest" className="text-right">Gross Interest</Label>
+								<Input id="edit_gross_interest" type="number" step="0.01" className="col-span-3" {...register('gross_interest')} />
+								{errors.gross_interest && <p className="col-span-4 text-right text-sm text-red-500">{errors.gross_interest.message}</p>}
 							</div>
-							<div>
-								<p className="text-xs text-muted-foreground">Total Net Interest</p>
-								<p className="text-lg font-semibold text-green-500">{formatCurrency(certificate.summary?.total_net_interest || 0)}</p>
+							<div className="grid grid-cols-4 items-center gap-4">
+								<Label htmlFor="edit_tax_withheld" className="text-right">Tax Withheld</Label>
+								<Input id="edit_tax_withheld" type="number" step="0.01" className="col-span-3" {...register('tax_withheld')} />
+								{errors.tax_withheld && <p className="col-span-4 text-right text-sm text-red-500">{errors.tax_withheld.message}</p>}
+							</div>
+							<div className="grid grid-cols-4 items-center gap-4">
+								<Label htmlFor="edit_net_interest" className="text-right">Net Interest</Label>
+								<Input id="edit_net_interest" type="number" step="0.01" className="col-span-3" {...register('net_interest')} />
+								{errors.net_interest && <p className="col-span-4 text-right text-sm text-red-500">{errors.net_interest.message}</p>}
+							</div>
+							<div className="grid grid-cols-4 items-center gap-4">
+								<Label htmlFor="edit_applied_rate" className="text-right">Rate (%)</Label>
+								<Input id="edit_applied_rate" type="number" step="0.01" className="col-span-3" {...register('applied_rate')} />
+								{errors.applied_rate && <p className="col-span-4 text-right text-sm text-red-500">{errors.applied_rate.message}</p>}
+							</div>
+							<div className="grid grid-cols-4 items-center gap-4">
+								<Label htmlFor="edit_applied_tax_rate" className="text-right">Tax Rate (%)</Label>
+								<Input id="edit_applied_tax_rate" type="number" step="0.01" className="col-span-3" {...register('applied_tax_rate')} />
+								{errors.applied_tax_rate && <p className="col-span-4 text-right text-sm text-red-500">{errors.applied_tax_rate.message}</p>}
+							</div>
+							<div className="grid grid-cols-4 items-center gap-4">
+								<Label htmlFor="edit_applied_capital" className="text-right">Capital</Label>
+								<Input id="edit_applied_capital" type="number" step="0.01" className="col-span-3" {...register('applied_capital')} />
+								{errors.applied_capital && <p className="col-span-4 text-right text-sm text-red-500">{errors.applied_capital.message}</p>}
 							</div>
 						</div>
-
-						<Tabs defaultValue="history">
-							<TabsList className="grid w-full grid-cols-2">
-								<TabsTrigger value="history">History</TabsTrigger>
-								<TabsTrigger value="chart">Chart</TabsTrigger>
-							</TabsList>
-							<TabsContent value="history" className="mt-4">
-								{payments.length === 0 ? (
-									<div className="py-8 text-center text-muted-foreground">No payments recorded yet.</div>
-								) : (
-									<ScrollArea className="h-[400px]">
-										<Table>
-											<TableHeader>
-												<TableRow>
-													<TableHead>Date</TableHead>
-													<TableHead className="text-right">Capital</TableHead>
-													<TableHead className="text-right">Rate</TableHead>
-													<TableHead className="text-right">Gross</TableHead>
-													<TableHead className="text-right">Tax</TableHead>
-													<TableHead className="text-right">Net</TableHead>
-												</TableRow>
-											</TableHeader>
-											<TableBody>
-												{payments.map((payment) => (
-													<TableRow key={payment.id}>
-														<TableCell>{new Date(payment.payment_date).toLocaleDateString()}</TableCell>
-														<TableCell className="text-right">{formatCurrency(payment.applied_capital)}</TableCell>
-														<TableCell className="text-right">{payment.applied_rate}%</TableCell>
-														<TableCell className="text-right">{formatCurrency(payment.gross_interest)}</TableCell>
-														<TableCell className="text-right text-orange-500">-{formatCurrency(payment.tax_withheld)}</TableCell>
-														<TableCell className="text-right text-green-500 font-medium">{formatCurrency(payment.net_interest)}</TableCell>
-													</TableRow>
-												))}
-											</TableBody>
-										</Table>
-									</ScrollArea>
-								)}
-							</TabsContent>
-							<TabsContent value="chart" className="mt-4">
-								<CertificateChart certificate={certificate} payments={payments} />
-							</TabsContent>
-						</Tabs>
-					</div>
-				) : null}
-			</DialogContent>
-		</Dialog>
+						<DialogFooter className="gap-2">
+							<Button type="button" variant="outline" onClick={() => setEditingPayment(null)}>Cancel</Button>
+							<Button type="submit" disabled={updatePaymentMutation.isPending}>
+								{updatePaymentMutation.isPending ? 'Saving...' : 'Save'}
+							</Button>
+						</DialogFooter>
+					</form>
+				</DialogContent>
+			</Dialog>
+		</>
 	)
 }

--- a/FrontendNextjs/gestor/hooks/queries/useCertificatesQuery.ts
+++ b/FrontendNextjs/gestor/hooks/queries/useCertificatesQuery.ts
@@ -8,6 +8,7 @@ import {
 	CertificateSummary,
 	CreateCertificateDTO,
 	UpdateCertificateDTO,
+	UpdateCertificatePaymentDTO,
 	SimulatePaymentDTO,
 	SimulationResult,
 } from '@/types/certificate'
@@ -89,6 +90,19 @@ export function useDeleteCertificateMutation() {
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: CERTIFICATE_KEYS.lists() })
 			queryClient.invalidateQueries({ queryKey: CERTIFICATE_KEYS.summary() })
+		},
+	})
+}
+
+export function useUpdateCertificatePaymentMutation() {
+	const queryClient = useQueryClient()
+	return useMutation({
+		mutationFn: async ({ paymentId, data }: { paymentId: string; data: UpdateCertificatePaymentDTO }) => {
+			const repo = await getCertificateRepository()
+			return repo.updatePayment(paymentId, data)
+		},
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: CERTIFICATE_KEYS.all })
 		},
 	})
 }

--- a/FrontendNextjs/gestor/types/certificate.ts
+++ b/FrontendNextjs/gestor/types/certificate.ts
@@ -41,6 +41,7 @@ export interface CertificatePayment {
 	applied_capital: number
 	transaction_id?: string
 	created_at: string
+	updated_at?: string
 }
 
 export interface CertificateSummary {
@@ -79,6 +80,18 @@ export interface UpdateCertificateDTO {
 	reinvest_interest?: boolean
 	payout_account_id?: string
 	status?: CertificateStatus
+}
+
+export interface UpdateCertificatePaymentDTO {
+	payment_date?: string
+	period_start?: string
+	period_end?: string
+	gross_interest?: number
+	tax_withheld?: number
+	net_interest?: number
+	applied_rate?: number
+	applied_tax_rate?: number
+	applied_capital?: number
 }
 
 export interface SimulatePaymentDTO {

--- a/e2e-test/tests/certificates.spec.ts
+++ b/e2e-test/tests/certificates.spec.ts
@@ -64,4 +64,56 @@ test.describe('Certificates @prod-write', () => {
 			return 'pending'
 		}, { timeout: 20000 }).toMatch(/removed|cancelled/)
 	})
+
+	test('edit a certificate payment', async ({ page }) => {
+		await gotoApp(page)
+
+		await page.locator('a[href="/app/certificates"]').first().click()
+		await page.waitForURL('**/app/certificates')
+
+		// Payments are generated lazily by the backend when listing certificates.
+		// A freshly created certificate won't have payments until its first cutDay
+		// passes, so we look for any existing certificate that already has payments.
+		const historyButtons = page.getByRole('button', { name: /History/i })
+		const count = await historyButtons.count()
+		test.skip(count === 0, 'No existing certificates found to test payment edit')
+
+		let foundPayments = false
+		const historyDialog = page.getByRole('dialog', { name: /Payment History/i })
+
+		for (let i = 0; i < count; i++) {
+			await historyButtons.nth(i).click()
+			await expect(historyDialog).toBeVisible()
+
+			const editBtn = historyDialog.getByRole('button', { name: /Edit payment/i }).first()
+			try {
+				await editBtn.waitFor({ state: 'visible', timeout: 3000 })
+				foundPayments = true
+				break
+			} catch {
+				await page.keyboard.press('Escape')
+				await expect(historyDialog).not.toBeVisible()
+			}
+		}
+
+		test.skip(!foundPayments, 'No certificates with existing payments found')
+
+		// Click edit on the first payment
+		const editButton = historyDialog.getByRole('button', { name: /Edit payment/i }).first()
+		await editButton.click()
+		const editDialog = page.getByRole('dialog', { name: /Edit Payment/i })
+		await expect(editDialog).toBeVisible()
+
+		// Change gross_interest
+		const grossInput = editDialog.locator('input#edit_gross_interest')
+		await grossInput.fill('999.99')
+
+		await editDialog.getByRole('button', { name: /Save/i }).click()
+		await expect(editDialog).not.toBeVisible({ timeout: 10000 })
+
+		// Verify the updated value appears in the table
+		await expect(historyDialog.getByText('DOP 999.99')).toBeVisible({ timeout: 10000 })
+
+		await page.keyboard.press('Escape')
+	})
 })


### PR DESCRIPTION
Add backend update endpoints and persistence for certificate payments so recorded interest entries can be corrected without manual database work. Expose the edit flow in the Next.js payment history modal and cover it with an end-to-end test.