### PR TITLE
fix(ci): remove invalid merge plugin from release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -20,11 +20,5 @@
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true
     }
-  },
-  "plugins": [
-    {
-      "type": "merge",
-      "merge": true
-    }
-  ]
+  }
 }


### PR DESCRIPTION
## Summary
- Remove the non-existent `merge` plugin that was causing release-please to fail with: `Unknown plugin type: merge`
- Combined release PRs are already the default behavior with `separate-pull-requests: false`

## Test plan
- [ ] After merge, verify release-please workflow succeeds and creates a release PR