### PR TITLE
fix(ci): auto-merge release PR and fix version.go updates

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,3 +21,12 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      # Auto-merge the release PR when CI passes
+      - name: Enable auto-merge on release PR
+        if: steps.release.outputs.pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER=$(echo '${{ steps.release.outputs.pr }}' | jq -r '.number')
+          gh pr merge "$PR_NUMBER" --auto --squash --repo ${{ github.repository }}

--- a/BackEnd/version.go
+++ b/BackEnd/version.go
@@ -1,3 +1,4 @@
 package main
 
-const Version = "0.2.0"
+// x-release-please-version
+const Version = "0.3.0"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,7 +10,11 @@
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
       "extra-files": [
-        "version.go"
+        {
+          "type": "generic",
+          "path": "version.go",
+          "glob": false
+        }
       ]
     },
     "FrontendNextjs/gestor": {


### PR DESCRIPTION
## Summary
- **Auto-merge**: Release PR now merges automatically (squash) once CI passes
- **version.go fix**: Use `x-release-please-version` annotation + generic updater so release-please bumps `BackEnd/version.go` on each release
- Sync `version.go` to `0.3.0` to match current manifest

## How it works
1. Push to `main` → release-please creates/updates a release PR
2. CI runs on the release PR
3. Once CI passes → the PR auto-merges (squash)
4. Merge triggers tag creation + GitHub Release

## Test plan
- [ ] After merge, verify next release-please run updates version.go in the release PR
- [ ] Verify auto-merge triggers after CI passes on the release PR