### PR TITLE
fix(ci): skip labeling in release-please to prevent failure

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,10 +17,12 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4.4.0
         id: release
+        continue-on-error: true
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          skip-labeling: true
 
       # Auto-merge the release PR when CI passes
       - name: Enable auto-merge on release PR


### PR DESCRIPTION
## Summary
- Add `skip-labeling: true` to avoid GitHub API race condition when labeling a just-created PR
- Add `continue-on-error: true` so the auto-merge step runs even if release-please has non-critical errors

## Test plan
- [ ] After merge, verify release-please workflow succeeds and auto-merge is enabled on the release PR