### PR TITLE
fix(ci): use inline annotation for version.go in release-please

### DIFF
--- a/BackEnd/version.go
+++ b/BackEnd/version.go
@@ -1,4 +1,3 @@
 package main
 
-// x-release-please-version
-const Version = "0.3.0"
+const Version = "0.4.0" // x-release-please-version


### PR DESCRIPTION
## Summary
Move `x-release-please-version` annotation to the same line as the version string so the generic updater can find and replace it. Also sync version.go to 0.4.0 to match the current manifest.

```go
// Before (not working):
// x-release-please-version
const Version = "0.3.0"

// After:
const Version = "0.4.0" // x-release-please-version
```

## Test plan
- [ ] After merge, verify the next release PR includes a version.go update