### PR TITLE
ci: only trigger E2E tests on app code changes

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,9 +1,12 @@
 name: E2E Tests
 
 on:
-
   pull_request:
     branches: [main, development]
+    paths:
+      - 'BackEnd/**'
+      - 'FrontendNextjs/**'
+      - 'e2e-test/**'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
Add path filters to the E2E workflow so it only runs when files in `BackEnd/`, `FrontendNextjs/`, or `e2e-test/` change. Saves ~10 min CI time on docs/config-only PRs.

`workflow_dispatch` is kept for manual triggers.