### PR TITLE
ci: only deploy backend on Railway when version changes

### DIFF
--- a/BackEnd/railway.toml
+++ b/BackEnd/railway.toml
@@ -1,0 +1,2 @@
+[build]
+watchPatterns = ["BackEnd/version.go"]


### PR DESCRIPTION
## Summary
Add `railway.toml` with watch paths so Railway only deploys when `BackEnd/version.go` changes (i.e., when release-please bumps the version).

This prevents duplicate deploys — currently every push to main triggers a Railway deploy, but we only want deploys on actual releases.

## How it works
```
PR merge → release-please creates release PR → release PR merges → version.go updated → Railway deploys
```

Without watch paths: 2 deploys per release (PR merge + version bump)
With watch paths: 1 deploy per release (only version bump)