### PR TITLE
fix(backend): MCP create_transaction not persisting data

### DIFF
--- a/BackEnd/internal/platform/mcp/tools.go
+++ b/BackEnd/internal/platform/mcp/tools.go
@@ -245,12 +245,11 @@ func (s *MCPServer) handleCreateTransaction(ctx context.Context, req mcp.CallToo
 		}
 	}
 
-	txCtx, commit, rollback, dbErr := s.withRLSTx(ctx, userID)
+	txCtx, _, rollback, dbErr := s.withRLSTx(ctx, userID)
 	if dbErr != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("database error: %s", dbErr)), nil
 	}
-	defer commit()
-	defer rollback()
+	defer rollback() // rollback is a no-op after a successful commit
 
 	if createErr := s.services.Transaction.CreateTransaction(
 		txCtx,
@@ -266,6 +265,12 @@ func (s *MCPServer) handleCreateTransaction(ctx context.Context, req mcp.CallToo
 		createdAt,
 	); createErr != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to create transaction: %s", createErr)), nil
+	}
+
+	// Commit explicitly after successful create — defer rollback above
+	// becomes a no-op since the tx is already committed.
+	if commitErr := mcpcontext.TxFromContext(txCtx).Commit(); commitErr != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to commit transaction: %s", commitErr)), nil
 	}
 
 	resp := map[string]string{"status": "created"}


### PR DESCRIPTION
## Root Cause

`defer commit()` followed by `defer rollback()` — Go executes defers in **LIFO order**, so `rollback()` ran **first**, undoing the transaction before `commit()` could execute.

```go
// BEFORE (broken)
defer commit()   // executes SECOND
defer rollback() // executes FIRST ← rolls back before commit!
```

Read-only tools (list_accounts, etc.) were unaffected because SELECT results are returned before rollback.

## Fix

Commit explicitly after successful save. Defer only rollback as a safety net (becomes no-op after commit).

```go
// AFTER (fixed)
defer rollback() // safety net, no-op after commit

// ... do work ...

tx.Commit() // explicit commit on success
```

## Test plan
- [x] `go build ./...` compiles
- [x] `make lint` passes
- [ ] Manual: create transaction via Claude Web MCP → verify it appears in DB and UI

Closes MYP-35