### PR TITLE
feat: batch MYP-41/42/44/45/46 (cards, dashboard, MCP)

### DIFF
--- a/BackEnd/cmd/api/boostrap/boostrap.go
+++ b/BackEnd/cmd/api/boostrap/boostrap.go
@@ -131,6 +131,8 @@ func Run() error {
 			Category:    services.categoryService,
 			Budget:      services.budgetService,
 			Analytics:   services.analyticsService,
+			CreditCard:  services.creditCardService,
+			Loan:        services.loanService,
 		}, db)
 
 		issuer := cfg.MCP.BaseURL

--- a/BackEnd/cmd/api/db/migrations/000041_create_card_balance_resets.down.sql
+++ b/BackEnd/cmd/api/db/migrations/000041_create_card_balance_resets.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS card_balance_resets;

--- a/BackEnd/cmd/api/db/migrations/000041_create_card_balance_resets.up.sql
+++ b/BackEnd/cmd/api/db/migrations/000041_create_card_balance_resets.up.sql
@@ -1,0 +1,27 @@
+CREATE TABLE card_balance_resets (
+    id VARCHAR(32) PRIMARY KEY,
+    balance_id VARCHAR(32) NOT NULL,
+    card_id VARCHAR(32) NOT NULL,
+    currency VARCHAR(3) NOT NULL,
+    previous_balance DECIMAL(15,2) NOT NULL,
+    notes TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    FOREIGN KEY (balance_id) REFERENCES card_balances(id) ON DELETE CASCADE,
+    FOREIGN KEY (card_id) REFERENCES credit_cards(account_id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_card_balance_resets_card ON card_balance_resets(card_id);
+CREATE INDEX idx_card_balance_resets_balance ON card_balance_resets(balance_id);
+CREATE INDEX idx_card_balance_resets_created_at ON card_balance_resets(created_at);
+
+ALTER TABLE card_balance_resets ENABLE ROW LEVEL SECURITY;
+ALTER TABLE card_balance_resets FORCE ROW LEVEL SECURITY;
+CREATE POLICY card_balance_resets_isolation ON card_balance_resets
+    USING (current_setting('app.is_admin', true) = 'true'
+        OR EXISTS (
+            SELECT 1 FROM account
+            JOIN credit_cards ON credit_cards.account_id = account.id
+            WHERE credit_cards.account_id = card_balance_resets.card_id
+              AND account.user_id = current_setting('app.current_user_id', true)
+        ));

--- a/BackEnd/internal/domain/creditcard/creditcard.go
+++ b/BackEnd/internal/domain/creditcard/creditcard.go
@@ -31,6 +31,16 @@ type CardBalance struct {
 	UpdatedAt      time.Time
 }
 
+type CardBalanceReset struct {
+	Id              string
+	BalanceId       string
+	CardId          string
+	Currency        string
+	PreviousBalance float64
+	Notes           string
+	CreatedAt       time.Time
+}
+
 type CardPayment struct {
 	Id               string
 	CardId           string

--- a/BackEnd/internal/platform/dto/creditcard/creditcardDTO.go
+++ b/BackEnd/internal/platform/dto/creditcard/creditcardDTO.go
@@ -72,6 +72,34 @@ func (r *CreatePaymentRequest) Validate() error {
 	return nil
 }
 
+type ResetBalanceRequest struct {
+	BalanceId string `json:"balance_id"`
+	Currency  string `json:"currency"`
+	Notes     string `json:"notes"`
+}
+
+type BalanceResetResponse struct {
+	Id              string    `json:"id"`
+	BalanceId       string    `json:"balance_id"`
+	CardId          string    `json:"card_id"`
+	Currency        string    `json:"currency"`
+	PreviousBalance float64   `json:"previous_balance"`
+	Notes           string    `json:"notes"`
+	CreatedAt       time.Time `json:"created_at"`
+}
+
+func NewBalanceResetResponse(r *creditcard.CardBalanceReset) *BalanceResetResponse {
+	return &BalanceResetResponse{
+		Id:              r.Id,
+		BalanceId:       r.BalanceId,
+		CardId:          r.CardId,
+		Currency:        r.Currency,
+		PreviousBalance: r.PreviousBalance,
+		Notes:           r.Notes,
+		CreatedAt:       r.CreatedAt,
+	}
+}
+
 type BalanceResponse struct {
 	Id                 string    `json:"id"`
 	Currency           string    `json:"currency"`

--- a/BackEnd/internal/platform/mcp/server.go
+++ b/BackEnd/internal/platform/mcp/server.go
@@ -8,6 +8,8 @@ import (
 	"github.com/osmait/gestorDePresupuesto/internal/services/analytics"
 	"github.com/osmait/gestorDePresupuesto/internal/services/budget"
 	"github.com/osmait/gestorDePresupuesto/internal/services/category"
+	"github.com/osmait/gestorDePresupuesto/internal/services/creditcard"
+	"github.com/osmait/gestorDePresupuesto/internal/services/loan"
 	"github.com/osmait/gestorDePresupuesto/internal/services/transaction"
 )
 
@@ -18,6 +20,8 @@ type Services struct {
 	Category    *category.CategoryServices
 	Budget      *budget.BudgetServices
 	Analytics   *analytics.AnalyticsService
+	CreditCard  *creditcard.CreditCardService
+	Loan        *loan.LoanService
 }
 
 // MCPServer wraps the mcp-go server and registers all tool handlers.

--- a/BackEnd/internal/platform/mcp/tools.go
+++ b/BackEnd/internal/platform/mcp/tools.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
+	transactionDomain "github.com/osmait/gestorDePresupuesto/internal/domain/transaction"
 	dto "github.com/osmait/gestorDePresupuesto/internal/platform/dto/transaction"
 	"github.com/osmait/gestorDePresupuesto/internal/platform/mcp/mcpcontext"
 )
@@ -29,12 +30,52 @@ func (s *MCPServer) registerTools() {
 
 	s.server.AddTool(
 		mcp.NewTool("list_transactions",
-			mcp.WithDescription("List recent transactions across all accounts for the authenticated user"),
+			mcp.WithDescription("List transactions for the authenticated user. Supports filtering by date range, account, category and type."),
 			mcp.WithNumber("limit",
-				mcp.Description("Maximum number of transactions to return (default 20)"),
+				mcp.Description("Maximum number of transactions to return (default 20, max 100)"),
+			),
+			mcp.WithString("date_from",
+				mcp.Description("Filter: start date in YYYY-MM-DD or YYYY/MM/DD format"),
+			),
+			mcp.WithString("date_to",
+				mcp.Description("Filter: end date in YYYY-MM-DD or YYYY/MM/DD format"),
+			),
+			mcp.WithString("account_id",
+				mcp.Description("Filter by account ID"),
+			),
+			mcp.WithString("category_id",
+				mcp.Description("Filter by category ID"),
+			),
+			mcp.WithString("type",
+				mcp.Description("Filter by transaction type"),
+				mcp.Enum("income", "bill", "all"),
 			),
 		),
 		s.handleListTransactions,
+	)
+
+	s.server.AddTool(
+		mcp.NewTool("update_transaction",
+			mcp.WithDescription("Replace an existing transaction's core fields. Before calling, use list_transactions to fetch the current values and pass the full set of fields — any omitted required field will be rejected."),
+			mcp.WithString("id", mcp.Required(), mcp.Description("ID of the transaction to update")),
+			mcp.WithString("name", mcp.Required(), mcp.Description("Transaction name")),
+			mcp.WithNumber("amount", mcp.Required(), mcp.Description("Amount (positive number)")),
+			mcp.WithString("type", mcp.Required(), mcp.Description("Transaction type"), mcp.Enum("income", "bill")),
+			mcp.WithString("account_id", mcp.Required(), mcp.Description("Account ID")),
+			mcp.WithString("category_id", mcp.Required(), mcp.Description("Category ID")),
+			mcp.WithString("description", mcp.Description("Optional description")),
+			mcp.WithString("currency", mcp.Description("Currency code (e.g. USD, DOP). Defaults to USD")),
+			mcp.WithString("date", mcp.Description("Transaction date in RFC3339 (optional, preserves original if omitted — but if you need to preserve it, pass it explicitly)")),
+		),
+		s.handleUpdateTransaction,
+	)
+
+	s.server.AddTool(
+		mcp.NewTool("delete_transaction",
+			mcp.WithDescription("Delete a transaction owned by the authenticated user"),
+			mcp.WithString("id", mcp.Required(), mcp.Description("ID of the transaction to delete")),
+		),
+		s.handleDeleteTransaction,
 	)
 
 	s.server.AddTool(
@@ -87,6 +128,8 @@ func (s *MCPServer) registerTools() {
 		),
 		s.handleAnalyzeSpending,
 	)
+
+	s.registerExtraTools()
 }
 
 // withRLSTx opens a PostgreSQL transaction, sets the RLS user-id session variable,
@@ -184,11 +227,32 @@ func (s *MCPServer) handleListTransactions(ctx context.Context, req mcp.CallTool
 	filter.Limit = limit
 	filter.Page = 1
 	filter.Offset = 0
-	// Ensure date range is calculated for the default filter
+	filter.DateFrom = req.GetString("date_from", "")
+	filter.DateTo = req.GetString("date_to", "")
+	filter.AccountId = req.GetString("account_id", "")
+	filter.CategoryId = req.GetString("category_id", "")
+	if typeFilter := req.GetString("type", ""); typeFilter != "" {
+		filter.Type = typeFilter
+	}
+
+	// Parse date strings into CalculatedDateFrom/To (the repository relies on these).
+	// When empty, leave as zero so no date filter is applied.
+	if filter.DateFrom != "" {
+		parsed, perr := parseMCPDate(filter.DateFrom)
+		if perr != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("invalid date_from: %s", perr)), nil
+		}
+		filter.CalculatedDateFrom = parsed
+	}
+	if filter.DateTo != "" {
+		parsed, perr := parseMCPDate(filter.DateTo)
+		if perr != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("invalid date_to: %s", perr)), nil
+		}
+		filter.CalculatedDateTo = parsed.Add(23*time.Hour + 59*time.Minute + 59*time.Second)
+	}
 	if calcErr := filter.Validate(); calcErr != nil {
-		// Non-fatal: proceed with defaults
-		filter = dto.NewTransactionFilter()
-		filter.Limit = limit
+		return mcp.NewToolResultError(fmt.Sprintf("invalid filter: %s", calcErr)), nil
 	}
 
 	result, err := s.services.Transaction.FindAllOfAllAccountsWithFilters(txCtx, userID, filter, false)
@@ -301,6 +365,118 @@ func (s *MCPServer) handleGetBalance(ctx context.Context, req mcp.CallToolReques
 	if err != nil {
 		return mcp.NewToolResultError("failed to serialize balances"), nil
 	}
+	return mcp.NewToolResultText(string(data)), nil
+}
+
+// parseMCPDate parses a date string accepting several common formats.
+func parseMCPDate(s string) (time.Time, error) {
+	layouts := []string{"2006-01-02", "2006/01/02", time.RFC3339}
+	for _, l := range layouts {
+		if t, err := time.Parse(l, s); err == nil {
+			return t, nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("unable to parse date: %s", s)
+}
+
+// handleUpdateTransaction updates an existing transaction owned by the authenticated user.
+func (s *MCPServer) handleUpdateTransaction(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	userID := mcpcontext.UserIDFromContext(ctx)
+	if userID == "" {
+		return mcp.NewToolResultError("missing user authentication"), nil
+	}
+
+	id, err := req.RequireString("id")
+	if err != nil {
+		return mcp.NewToolResultError("id is required"), nil
+	}
+	name, err := req.RequireString("name")
+	if err != nil {
+		return mcp.NewToolResultError("name is required"), nil
+	}
+	amount := req.GetFloat("amount", 0)
+	if amount <= 0 {
+		return mcp.NewToolResultError("amount must be a positive number"), nil
+	}
+	txType, err := req.RequireString("type")
+	if err != nil {
+		return mcp.NewToolResultError("type is required"), nil
+	}
+	accountID, err := req.RequireString("account_id")
+	if err != nil {
+		return mcp.NewToolResultError("account_id is required"), nil
+	}
+	categoryID, err := req.RequireString("category_id")
+	if err != nil {
+		return mcp.NewToolResultError("category_id is required"), nil
+	}
+
+	txCtx, _, rollback, dbErr := s.withRLSTx(ctx, userID)
+	if dbErr != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("database error: %s", dbErr)), nil
+	}
+	defer rollback()
+
+	updated := transactionDomain.NewTransaction(
+		id,
+		name,
+		req.GetString("description", ""),
+		txType,
+		accountID,
+		categoryID,
+		amount,
+	)
+	updated.UserId = userID
+	updated.Currency = req.GetString("currency", "")
+	if dateStr := req.GetString("date", ""); dateStr != "" {
+		parsed, perr := time.Parse(time.RFC3339, dateStr)
+		if perr != nil {
+			return mcp.NewToolResultError("invalid date: expected RFC3339 format"), nil
+		}
+		updated.CreatedAt = parsed
+	}
+
+	if updateErr := s.services.Transaction.UpdateTransaction(txCtx, id, updated); updateErr != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to update transaction: %s", updateErr)), nil
+	}
+
+	if commitErr := mcpcontext.TxFromContext(txCtx).Commit(); commitErr != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to commit transaction: %s", commitErr)), nil
+	}
+
+	resp := map[string]string{"status": "updated", "id": id}
+	data, _ := json.Marshal(resp)
+	return mcp.NewToolResultText(string(data)), nil
+}
+
+// handleDeleteTransaction deletes a transaction owned by the authenticated user.
+func (s *MCPServer) handleDeleteTransaction(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	userID := mcpcontext.UserIDFromContext(ctx)
+	if userID == "" {
+		return mcp.NewToolResultError("missing user authentication"), nil
+	}
+
+	id, err := req.RequireString("id")
+	if err != nil {
+		return mcp.NewToolResultError("id is required"), nil
+	}
+
+	txCtx, _, rollback, dbErr := s.withRLSTx(ctx, userID)
+	if dbErr != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("database error: %s", dbErr)), nil
+	}
+	defer rollback()
+
+	if delErr := s.services.Transaction.DeleteTransaction(txCtx, id, userID); delErr != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to delete transaction: %s", delErr)), nil
+	}
+
+	if commitErr := mcpcontext.TxFromContext(txCtx).Commit(); commitErr != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to commit transaction: %s", commitErr)), nil
+	}
+
+	resp := map[string]string{"status": "deleted", "id": id}
+	data, _ := json.Marshal(resp)
 	return mcp.NewToolResultText(string(data)), nil
 }
 

--- a/BackEnd/internal/platform/mcp/tools_extra.go
+++ b/BackEnd/internal/platform/mcp/tools_extra.go
@@ -1,0 +1,726 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	accountDTO "github.com/osmait/gestorDePresupuesto/internal/platform/dto/account"
+	categoryDTO "github.com/osmait/gestorDePresupuesto/internal/platform/dto/category"
+	creditcardDTO "github.com/osmait/gestorDePresupuesto/internal/platform/dto/creditcard"
+	loanDTO "github.com/osmait/gestorDePresupuesto/internal/platform/dto/loan"
+	"github.com/osmait/gestorDePresupuesto/internal/platform/mcp/mcpcontext"
+	"github.com/osmait/gestorDePresupuesto/internal/services/analytics"
+)
+
+// registerExtraTools registers the extended MCP tools (accounts, categories,
+// credit cards, loans, analytics by period). Called from registerTools.
+func (s *MCPServer) registerExtraTools() {
+	// --- Accounts ---
+	s.server.AddTool(
+		mcp.NewTool("create_account",
+			mcp.WithDescription("Create a new bank account for the authenticated user"),
+			mcp.WithString("name", mcp.Required(), mcp.Description("Account name")),
+			mcp.WithString("bank", mcp.Required(), mcp.Description("Bank name")),
+			mcp.WithNumber("initial_balance", mcp.Description("Initial balance (default 0)")),
+		),
+		s.handleCreateAccount,
+	)
+	s.server.AddTool(
+		mcp.NewTool("update_account",
+			mcp.WithDescription("Update an account's name and bank"),
+			mcp.WithString("id", mcp.Required(), mcp.Description("Account ID")),
+			mcp.WithString("name", mcp.Required(), mcp.Description("New name")),
+			mcp.WithString("bank", mcp.Required(), mcp.Description("New bank")),
+		),
+		s.handleUpdateAccount,
+	)
+	s.server.AddTool(
+		mcp.NewTool("delete_account",
+			mcp.WithDescription("Delete an account owned by the authenticated user"),
+			mcp.WithString("id", mcp.Required(), mcp.Description("Account ID")),
+		),
+		s.handleDeleteAccount,
+	)
+
+	// --- Categories ---
+	s.server.AddTool(
+		mcp.NewTool("create_category",
+			mcp.WithDescription("Create a new transaction category"),
+			mcp.WithString("name", mcp.Required(), mcp.Description("Category name")),
+			mcp.WithString("icon", mcp.Required(), mcp.Description("Emoji or icon identifier")),
+			mcp.WithString("color", mcp.Required(), mcp.Description("Hex color (e.g. #FF6B6B)")),
+		),
+		s.handleCreateCategory,
+	)
+	s.server.AddTool(
+		mcp.NewTool("update_category",
+			mcp.WithDescription("Update an existing category"),
+			mcp.WithString("id", mcp.Required(), mcp.Description("Category ID")),
+			mcp.WithString("name", mcp.Required(), mcp.Description("New name")),
+			mcp.WithString("icon", mcp.Required(), mcp.Description("New icon")),
+			mcp.WithString("color", mcp.Required(), mcp.Description("New color")),
+		),
+		s.handleUpdateCategory,
+	)
+	s.server.AddTool(
+		mcp.NewTool("delete_category",
+			mcp.WithDescription("Delete a category owned by the authenticated user"),
+			mcp.WithString("id", mcp.Required(), mcp.Description("Category ID")),
+		),
+		s.handleDeleteCategory,
+	)
+
+	// --- Balance / analytics by period ---
+	s.server.AddTool(
+		mcp.NewTool("balance_by_period",
+			mcp.WithDescription("Return income, expenses and net for a period (current month by default)"),
+			mcp.WithString("period", mcp.Description("Preset period"), mcp.Enum("this_week", "this_month", "last_month", "this_year", "custom")),
+			mcp.WithString("date_from", mcp.Description("Custom start date YYYY-MM-DD (required when period=custom)")),
+			mcp.WithString("date_to", mcp.Description("Custom end date YYYY-MM-DD (required when period=custom)")),
+		),
+		s.handleBalanceByPeriod,
+	)
+	s.server.AddTool(
+		mcp.NewTool("financial_summary",
+			mcp.WithDescription("Return a financial summary with current month, previous month and percentage change"),
+		),
+		s.handleFinancialSummary,
+	)
+
+	// --- Credit cards ---
+	s.server.AddTool(
+		mcp.NewTool("list_credit_cards",
+			mcp.WithDescription("List all credit cards with their current balances"),
+		),
+		s.handleListCreditCards,
+	)
+	s.server.AddTool(
+		mcp.NewTool("credit_card_summary",
+			mcp.WithDescription("Return aggregate credit card metrics: total debt, total limit and utilization per currency"),
+		),
+		s.handleCreditCardSummary,
+	)
+	s.server.AddTool(
+		mcp.NewTool("pay_credit_card",
+			mcp.WithDescription("Pay a credit card from a bank account"),
+			mcp.WithString("card_id", mcp.Required(), mcp.Description("Credit card (account) ID")),
+			mcp.WithString("from_account_id", mcp.Required(), mcp.Description("Source account ID")),
+			mcp.WithString("currency", mcp.Required(), mcp.Description("Payment currency (e.g. DOP, USD)")),
+			mcp.WithNumber("amount", mcp.Required(), mcp.Description("Amount in the card's currency")),
+			mcp.WithNumber("exchange_rate", mcp.Description("Exchange rate when source and card currencies differ")),
+			mcp.WithBoolean("includes_interest", mcp.Description("Whether the payment includes interest")),
+			mcp.WithNumber("interest_amount", mcp.Description("Interest portion (if any)")),
+			mcp.WithString("notes", mcp.Description("Optional notes")),
+		),
+		s.handlePayCreditCard,
+	)
+	s.server.AddTool(
+		mcp.NewTool("reset_credit_card_balance",
+			mcp.WithDescription("Reset a credit card balance to zero for a given currency, storing the previous balance in history"),
+			mcp.WithString("card_id", mcp.Required(), mcp.Description("Credit card (account) ID")),
+			mcp.WithString("balance_id", mcp.Description("Specific balance ID to reset")),
+			mcp.WithString("currency", mcp.Description("Currency to reset (use if balance_id is unknown)")),
+			mcp.WithString("notes", mcp.Description("Optional notes")),
+		),
+		s.handleResetCreditCardBalance,
+	)
+
+	// --- Loans ---
+	s.server.AddTool(
+		mcp.NewTool("list_loans",
+			mcp.WithDescription("List all loans for the authenticated user"),
+		),
+		s.handleListLoans,
+	)
+	s.server.AddTool(
+		mcp.NewTool("get_loan",
+			mcp.WithDescription("Get loan details including installments and payments"),
+			mcp.WithString("id", mcp.Required(), mcp.Description("Loan ID")),
+		),
+		s.handleGetLoan,
+	)
+	s.server.AddTool(
+		mcp.NewTool("create_loan",
+			mcp.WithDescription("Create a new loan issued from a source account"),
+			mcp.WithString("borrower_name", mcp.Required(), mcp.Description("Borrower name")),
+			mcp.WithNumber("principal_amount", mcp.Required(), mcp.Description("Principal amount")),
+			mcp.WithString("interest_mode", mcp.Required(), mcp.Description("Interest mode"), mcp.Enum("fixed_total", "none")),
+			mcp.WithNumber("annual_rate", mcp.Description("Annual rate (percent, 0-100)")),
+			mcp.WithNumber("term_months", mcp.Required(), mcp.Description("Term in months (1-120)")),
+			mcp.WithString("source_account_id", mcp.Required(), mcp.Description("Account funding the loan")),
+			mcp.WithString("currency", mcp.Description("Currency code (defaults to DOP)")),
+			mcp.WithString("start_date", mcp.Description("Start date YYYY-MM-DD (defaults to today)")),
+			mcp.WithString("borrower_contact", mcp.Description("Optional contact info")),
+			mcp.WithString("notes", mcp.Description("Optional notes")),
+		),
+		s.handleCreateLoan,
+	)
+	s.server.AddTool(
+		mcp.NewTool("register_loan_payment",
+			mcp.WithDescription("Register a payment received for a loan"),
+			mcp.WithString("loan_id", mcp.Required(), mcp.Description("Loan ID")),
+			mcp.WithString("destination_account_id", mcp.Required(), mcp.Description("Account that receives the payment")),
+			mcp.WithNumber("amount", mcp.Required(), mcp.Description("Payment amount")),
+			mcp.WithString("payment_date", mcp.Description("Payment date YYYY-MM-DD (defaults to today)")),
+			mcp.WithString("notes", mcp.Description("Optional notes")),
+		),
+		s.handleRegisterLoanPayment,
+	)
+	s.server.AddTool(
+		mcp.NewTool("loan_summary",
+			mcp.WithDescription("Return aggregated loan metrics for the authenticated user"),
+		),
+		s.handleLoanSummary,
+	)
+}
+
+// withRLSTxResult is a small helper to make the commit-on-success pattern concise.
+func (s *MCPServer) runRW(ctx context.Context, userID string, fn func(ctx context.Context) (interface{}, error)) (*mcp.CallToolResult, error) {
+	txCtx, _, rollback, err := s.withRLSTx(ctx, userID)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("database error: %s", err)), nil
+	}
+	defer rollback()
+
+	result, fnErr := fn(txCtx)
+	if fnErr != nil {
+		return mcp.NewToolResultError(fnErr.Error()), nil
+	}
+	if commitErr := mcpcontext.TxFromContext(txCtx).Commit(); commitErr != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to commit transaction: %s", commitErr)), nil
+	}
+
+	data, _ := json.Marshal(result)
+	return mcp.NewToolResultText(string(data)), nil
+}
+
+func (s *MCPServer) runRO(ctx context.Context, userID string, fn func(ctx context.Context) (interface{}, error)) (*mcp.CallToolResult, error) {
+	txCtx, commit, rollback, err := s.withRLSTx(ctx, userID)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("database error: %s", err)), nil
+	}
+	defer commit()
+	defer rollback()
+
+	result, fnErr := fn(txCtx)
+	if fnErr != nil {
+		return mcp.NewToolResultError(fnErr.Error()), nil
+	}
+	data, _ := json.Marshal(result)
+	return mcp.NewToolResultText(string(data)), nil
+}
+
+func authUserID(ctx context.Context) (string, *mcp.CallToolResult) {
+	userID := mcpcontext.UserIDFromContext(ctx)
+	if userID == "" {
+		return "", mcp.NewToolResultError("missing user authentication")
+	}
+	return userID, nil
+}
+
+// =============== ACCOUNTS ===============
+
+func (s *MCPServer) handleCreateAccount(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	userID, fail := authUserID(ctx)
+	if fail != nil {
+		return fail, nil
+	}
+	name, err := req.RequireString("name")
+	if err != nil {
+		return mcp.NewToolResultError("name is required"), nil
+	}
+	bank, err := req.RequireString("bank")
+	if err != nil {
+		return mcp.NewToolResultError("bank is required"), nil
+	}
+	initialBalance := req.GetFloat("initial_balance", 0)
+
+	return s.runRW(ctx, userID, func(txCtx context.Context) (interface{}, error) {
+		if createErr := s.services.Account.CreateAccount(txCtx, name, bank, initialBalance, userID); createErr != nil {
+			return nil, fmt.Errorf("failed to create account: %w", createErr)
+		}
+		return map[string]string{"status": "created"}, nil
+	})
+}
+
+func (s *MCPServer) handleUpdateAccount(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	userID, fail := authUserID(ctx)
+	if fail != nil {
+		return fail, nil
+	}
+	id, err := req.RequireString("id")
+	if err != nil {
+		return mcp.NewToolResultError("id is required"), nil
+	}
+	name, err := req.RequireString("name")
+	if err != nil {
+		return mcp.NewToolResultError("name is required"), nil
+	}
+	bank, err := req.RequireString("bank")
+	if err != nil {
+		return mcp.NewToolResultError("bank is required"), nil
+	}
+
+	return s.runRW(ctx, userID, func(txCtx context.Context) (interface{}, error) {
+		upd := accountDTO.NewAccountUpdateRequest(name, bank)
+		if updErr := s.services.Account.UpdateAccount(txCtx, id, upd, userID); updErr != nil {
+			return nil, fmt.Errorf("failed to update account: %w", updErr)
+		}
+		return map[string]string{"status": "updated", "id": id}, nil
+	})
+}
+
+func (s *MCPServer) handleDeleteAccount(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	userID, fail := authUserID(ctx)
+	if fail != nil {
+		return fail, nil
+	}
+	id, err := req.RequireString("id")
+	if err != nil {
+		return mcp.NewToolResultError("id is required"), nil
+	}
+	return s.runRW(ctx, userID, func(txCtx context.Context) (interface{}, error) {
+		if delErr := s.services.Account.DeleteAccount(txCtx, id, userID); delErr != nil {
+			return nil, fmt.Errorf("failed to delete account: %w", delErr)
+		}
+		return map[string]string{"status": "deleted", "id": id}, nil
+	})
+}
+
+// =============== CATEGORIES ===============
+
+func (s *MCPServer) handleCreateCategory(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	userID, fail := authUserID(ctx)
+	if fail != nil {
+		return fail, nil
+	}
+	name, err := req.RequireString("name")
+	if err != nil {
+		return mcp.NewToolResultError("name is required"), nil
+	}
+	icon, err := req.RequireString("icon")
+	if err != nil {
+		return mcp.NewToolResultError("icon is required"), nil
+	}
+	color, err := req.RequireString("color")
+	if err != nil {
+		return mcp.NewToolResultError("color is required"), nil
+	}
+
+	return s.runRW(ctx, userID, func(txCtx context.Context) (interface{}, error) {
+		catReq := categoryDTO.NewCategoryRequest(name, icon, color)
+		if createErr := s.services.Category.CreateCategory(txCtx, catReq, userID); createErr != nil {
+			return nil, fmt.Errorf("failed to create category: %w", createErr)
+		}
+		return map[string]string{"status": "created"}, nil
+	})
+}
+
+func (s *MCPServer) handleUpdateCategory(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	userID, fail := authUserID(ctx)
+	if fail != nil {
+		return fail, nil
+	}
+	id, err := req.RequireString("id")
+	if err != nil {
+		return mcp.NewToolResultError("id is required"), nil
+	}
+	name, err := req.RequireString("name")
+	if err != nil {
+		return mcp.NewToolResultError("name is required"), nil
+	}
+	icon, err := req.RequireString("icon")
+	if err != nil {
+		return mcp.NewToolResultError("icon is required"), nil
+	}
+	color, err := req.RequireString("color")
+	if err != nil {
+		return mcp.NewToolResultError("color is required"), nil
+	}
+
+	return s.runRW(ctx, userID, func(txCtx context.Context) (interface{}, error) {
+		catReq := categoryDTO.NewCategoryRequest(name, icon, color)
+		if updErr := s.services.Category.UpdateCategory(txCtx, catReq, id, userID); updErr != nil {
+			return nil, fmt.Errorf("failed to update category: %w", updErr)
+		}
+		return map[string]string{"status": "updated", "id": id}, nil
+	})
+}
+
+func (s *MCPServer) handleDeleteCategory(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	userID, fail := authUserID(ctx)
+	if fail != nil {
+		return fail, nil
+	}
+	id, err := req.RequireString("id")
+	if err != nil {
+		return mcp.NewToolResultError("id is required"), nil
+	}
+	return s.runRW(ctx, userID, func(txCtx context.Context) (interface{}, error) {
+		if delErr := s.services.Category.Delete(txCtx, id, userID); delErr != nil {
+			return nil, fmt.Errorf("failed to delete category: %w", delErr)
+		}
+		return map[string]string{"status": "deleted", "id": id}, nil
+	})
+}
+
+// =============== ANALYTICS BY PERIOD ===============
+
+func resolvePeriodRange(period, dateFrom, dateTo string) (time.Time, time.Time, error) {
+	now := time.Now()
+	switch period {
+	case "", "this_month":
+		from := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location())
+		to := from.AddDate(0, 1, 0).Add(-time.Nanosecond)
+		return from, to, nil
+	case "last_month":
+		prev := now.AddDate(0, -1, 0)
+		from := time.Date(prev.Year(), prev.Month(), 1, 0, 0, 0, 0, now.Location())
+		to := from.AddDate(0, 1, 0).Add(-time.Nanosecond)
+		return from, to, nil
+	case "this_week":
+		weekday := int(now.Weekday())
+		if weekday == 0 {
+			weekday = 7
+		}
+		from := now.AddDate(0, 0, -(weekday - 1)).Truncate(24 * time.Hour)
+		to := from.AddDate(0, 0, 6).Add(23*time.Hour + 59*time.Minute + 59*time.Second)
+		return from, to, nil
+	case "this_year":
+		from := time.Date(now.Year(), 1, 1, 0, 0, 0, 0, now.Location())
+		to := time.Date(now.Year()+1, 1, 1, 0, 0, 0, 0, now.Location()).Add(-time.Nanosecond)
+		return from, to, nil
+	case "custom":
+		if dateFrom == "" || dateTo == "" {
+			return time.Time{}, time.Time{}, fmt.Errorf("date_from and date_to are required when period=custom")
+		}
+		from, err := parseMCPDate(dateFrom)
+		if err != nil {
+			return time.Time{}, time.Time{}, fmt.Errorf("invalid date_from: %w", err)
+		}
+		to, err := parseMCPDate(dateTo)
+		if err != nil {
+			return time.Time{}, time.Time{}, fmt.Errorf("invalid date_to: %w", err)
+		}
+		return from, to.Add(23*time.Hour + 59*time.Minute + 59*time.Second), nil
+	default:
+		return time.Time{}, time.Time{}, fmt.Errorf("invalid period: %s", period)
+	}
+}
+
+func (s *MCPServer) handleBalanceByPeriod(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	userID, fail := authUserID(ctx)
+	if fail != nil {
+		return fail, nil
+	}
+	period := req.GetString("period", "this_month")
+	from, to, perr := resolvePeriodRange(period, req.GetString("date_from", ""), req.GetString("date_to", ""))
+	if perr != nil {
+		return mcp.NewToolResultError(perr.Error()), nil
+	}
+
+	return s.runRO(ctx, userID, func(txCtx context.Context) (interface{}, error) {
+		summary, err := s.services.Analytics.GetDashboardSummary(txCtx, userID, analytics.DashboardFilters{
+			DateFrom: from,
+			DateTo:   to,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to compute balance: %w", err)
+		}
+		return map[string]interface{}{
+			"period":         period,
+			"date_from":      from.Format("2006-01-02"),
+			"date_to":        to.Format("2006-01-02"),
+			"total_income":   summary.TotalIncome,
+			"total_expenses": summary.TotalExpenses,
+			"net_amount":     summary.NetAmount,
+			"usd_to_dop":     summary.UsdToDopRate,
+		}, nil
+	})
+}
+
+func (s *MCPServer) handleFinancialSummary(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	userID, fail := authUserID(ctx)
+	if fail != nil {
+		return fail, nil
+	}
+
+	currFrom, currTo, _ := resolvePeriodRange("this_month", "", "")
+	prevFrom, prevTo, _ := resolvePeriodRange("last_month", "", "")
+
+	return s.runRO(ctx, userID, func(txCtx context.Context) (interface{}, error) {
+		curr, err := s.services.Analytics.GetDashboardSummary(txCtx, userID, analytics.DashboardFilters{DateFrom: currFrom, DateTo: currTo})
+		if err != nil {
+			return nil, fmt.Errorf("failed to load current month: %w", err)
+		}
+		prev, err := s.services.Analytics.GetDashboardSummary(txCtx, userID, analytics.DashboardFilters{DateFrom: prevFrom, DateTo: prevTo})
+		if err != nil {
+			return nil, fmt.Errorf("failed to load previous month: %w", err)
+		}
+		pctChange := func(curr, prev float64) float64 {
+			if prev == 0 {
+				if curr == 0 {
+					return 0
+				}
+				return 100
+			}
+			return ((curr - prev) / prev) * 100
+		}
+		return map[string]interface{}{
+			"current_month": map[string]interface{}{
+				"date_from": currFrom.Format("2006-01-02"),
+				"date_to":   currTo.Format("2006-01-02"),
+				"income":    curr.TotalIncome,
+				"expenses":  curr.TotalExpenses,
+				"net":       curr.NetAmount,
+			},
+			"previous_month": map[string]interface{}{
+				"date_from": prevFrom.Format("2006-01-02"),
+				"date_to":   prevTo.Format("2006-01-02"),
+				"income":    prev.TotalIncome,
+				"expenses":  prev.TotalExpenses,
+				"net":       prev.NetAmount,
+			},
+			"change_percent": map[string]float64{
+				"income":   pctChange(curr.TotalIncome, prev.TotalIncome),
+				"expenses": pctChange(curr.TotalExpenses, prev.TotalExpenses),
+				"net":      pctChange(curr.NetAmount, prev.NetAmount),
+			},
+			"accounts_total": curr.AccountsTotal,
+			"usd_to_dop":     curr.UsdToDopRate,
+		}, nil
+	})
+}
+
+// =============== CREDIT CARDS ===============
+
+func (s *MCPServer) handleListCreditCards(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	userID, fail := authUserID(ctx)
+	if fail != nil {
+		return fail, nil
+	}
+	if s.services.CreditCard == nil {
+		return mcp.NewToolResultError("credit card service not configured"), nil
+	}
+	return s.runRO(ctx, userID, func(txCtx context.Context) (interface{}, error) {
+		return s.services.CreditCard.FindAllCards(txCtx, userID)
+	})
+}
+
+func (s *MCPServer) handleCreditCardSummary(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	userID, fail := authUserID(ctx)
+	if fail != nil {
+		return fail, nil
+	}
+	if s.services.CreditCard == nil {
+		return mcp.NewToolResultError("credit card service not configured"), nil
+	}
+	return s.runRO(ctx, userID, func(txCtx context.Context) (interface{}, error) {
+		return s.services.CreditCard.GetSummary(txCtx, userID)
+	})
+}
+
+func (s *MCPServer) handlePayCreditCard(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	userID, fail := authUserID(ctx)
+	if fail != nil {
+		return fail, nil
+	}
+	if s.services.CreditCard == nil {
+		return mcp.NewToolResultError("credit card service not configured"), nil
+	}
+	cardID, err := req.RequireString("card_id")
+	if err != nil {
+		return mcp.NewToolResultError("card_id is required"), nil
+	}
+	fromAccount, err := req.RequireString("from_account_id")
+	if err != nil {
+		return mcp.NewToolResultError("from_account_id is required"), nil
+	}
+	currency, err := req.RequireString("currency")
+	if err != nil {
+		return mcp.NewToolResultError("currency is required"), nil
+	}
+	amount := req.GetFloat("amount", 0)
+	if amount <= 0 {
+		return mcp.NewToolResultError("amount must be positive"), nil
+	}
+
+	payReq := &creditcardDTO.CreatePaymentRequest{
+		FromAccountId:    fromAccount,
+		Currency:         currency,
+		Amount:           amount,
+		ExchangeRate:     req.GetFloat("exchange_rate", 0),
+		IncludesInterest: req.GetBool("includes_interest", false),
+		InterestAmount:   req.GetFloat("interest_amount", 0),
+		Notes:            req.GetString("notes", ""),
+	}
+
+	return s.runRW(ctx, userID, func(txCtx context.Context) (interface{}, error) {
+		resp, payErr := s.services.CreditCard.CreatePayment(txCtx, cardID, userID, payReq)
+		if payErr != nil {
+			return nil, fmt.Errorf("failed to pay credit card: %w", payErr)
+		}
+		return resp, nil
+	})
+}
+
+func (s *MCPServer) handleResetCreditCardBalance(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	userID, fail := authUserID(ctx)
+	if fail != nil {
+		return fail, nil
+	}
+	if s.services.CreditCard == nil {
+		return mcp.NewToolResultError("credit card service not configured"), nil
+	}
+	cardID, err := req.RequireString("card_id")
+	if err != nil {
+		return mcp.NewToolResultError("card_id is required"), nil
+	}
+
+	resetReq := &creditcardDTO.ResetBalanceRequest{
+		BalanceId: req.GetString("balance_id", ""),
+		Currency:  req.GetString("currency", ""),
+		Notes:     req.GetString("notes", ""),
+	}
+	if resetReq.BalanceId == "" && resetReq.Currency == "" {
+		return mcp.NewToolResultError("balance_id or currency is required"), nil
+	}
+
+	return s.runRW(ctx, userID, func(txCtx context.Context) (interface{}, error) {
+		return s.services.CreditCard.ResetCardBalance(txCtx, cardID, userID, resetReq)
+	})
+}
+
+// =============== LOANS ===============
+
+func (s *MCPServer) handleListLoans(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	userID, fail := authUserID(ctx)
+	if fail != nil {
+		return fail, nil
+	}
+	if s.services.Loan == nil {
+		return mcp.NewToolResultError("loan service not configured"), nil
+	}
+	return s.runRO(ctx, userID, func(txCtx context.Context) (interface{}, error) {
+		return s.services.Loan.FindAll(txCtx, userID)
+	})
+}
+
+func (s *MCPServer) handleGetLoan(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	userID, fail := authUserID(ctx)
+	if fail != nil {
+		return fail, nil
+	}
+	if s.services.Loan == nil {
+		return mcp.NewToolResultError("loan service not configured"), nil
+	}
+	id, err := req.RequireString("id")
+	if err != nil {
+		return mcp.NewToolResultError("id is required"), nil
+	}
+	return s.runRO(ctx, userID, func(txCtx context.Context) (interface{}, error) {
+		return s.services.Loan.FindById(txCtx, id, userID)
+	})
+}
+
+func (s *MCPServer) handleCreateLoan(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	userID, fail := authUserID(ctx)
+	if fail != nil {
+		return fail, nil
+	}
+	if s.services.Loan == nil {
+		return mcp.NewToolResultError("loan service not configured"), nil
+	}
+	borrower, err := req.RequireString("borrower_name")
+	if err != nil {
+		return mcp.NewToolResultError("borrower_name is required"), nil
+	}
+	principal := req.GetFloat("principal_amount", 0)
+	if principal <= 0 {
+		return mcp.NewToolResultError("principal_amount must be positive"), nil
+	}
+	interestMode, err := req.RequireString("interest_mode")
+	if err != nil {
+		return mcp.NewToolResultError("interest_mode is required"), nil
+	}
+	termMonths := int(req.GetFloat("term_months", 0))
+	if termMonths <= 0 {
+		return mcp.NewToolResultError("term_months must be positive"), nil
+	}
+	sourceAccount, err := req.RequireString("source_account_id")
+	if err != nil {
+		return mcp.NewToolResultError("source_account_id is required"), nil
+	}
+
+	loanReq := &loanDTO.CreateLoanRequest{
+		BorrowerName:    borrower,
+		BorrowerContact: req.GetString("borrower_contact", ""),
+		PrincipalAmount: principal,
+		Currency:        req.GetString("currency", ""),
+		InterestMode:    interestMode,
+		AnnualRate:      req.GetFloat("annual_rate", 0),
+		TermMonths:      termMonths,
+		StartDate:       req.GetString("start_date", ""),
+		SourceAccountId: sourceAccount,
+		Notes:           req.GetString("notes", ""),
+	}
+	if validErr := loanReq.Validate(); validErr != nil {
+		return mcp.NewToolResultError(validErr.Error()), nil
+	}
+
+	return s.runRW(ctx, userID, func(txCtx context.Context) (interface{}, error) {
+		return s.services.Loan.CreateLoan(txCtx, loanReq, userID)
+	})
+}
+
+func (s *MCPServer) handleRegisterLoanPayment(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	userID, fail := authUserID(ctx)
+	if fail != nil {
+		return fail, nil
+	}
+	if s.services.Loan == nil {
+		return mcp.NewToolResultError("loan service not configured"), nil
+	}
+	loanID, err := req.RequireString("loan_id")
+	if err != nil {
+		return mcp.NewToolResultError("loan_id is required"), nil
+	}
+	destAccount, err := req.RequireString("destination_account_id")
+	if err != nil {
+		return mcp.NewToolResultError("destination_account_id is required"), nil
+	}
+	amount := req.GetFloat("amount", 0)
+	if amount <= 0 {
+		return mcp.NewToolResultError("amount must be positive"), nil
+	}
+
+	payReq := &loanDTO.RegisterLoanPaymentRequest{
+		DestinationAccountId: destAccount,
+		Amount:               amount,
+		PaymentDate:          req.GetString("payment_date", ""),
+		Notes:                req.GetString("notes", ""),
+	}
+	if validErr := payReq.Validate(); validErr != nil {
+		return mcp.NewToolResultError(validErr.Error()), nil
+	}
+
+	return s.runRW(ctx, userID, func(txCtx context.Context) (interface{}, error) {
+		return s.services.Loan.RegisterPayment(txCtx, loanID, userID, payReq)
+	})
+}
+
+func (s *MCPServer) handleLoanSummary(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	userID, fail := authUserID(ctx)
+	if fail != nil {
+		return fail, nil
+	}
+	if s.services.Loan == nil {
+		return mcp.NewToolResultError("loan service not configured"), nil
+	}
+	return s.runRO(ctx, userID, func(txCtx context.Context) (interface{}, error) {
+		return s.services.Loan.GetSummary(txCtx, userID)
+	})
+}

--- a/BackEnd/internal/platform/server/handler/creditcard/creditcardHandler.go
+++ b/BackEnd/internal/platform/server/handler/creditcard/creditcardHandler.go
@@ -106,6 +106,37 @@ func UpdateCardBalance(service *creditcard.CreditCardService) gin.HandlerFunc {
 	}
 }
 
+func ResetCardBalance(service *creditcard.CreditCardService) gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		userId := ctx.GetString("X-User-Id")
+		cardId := ctx.Param("id")
+		var req dto.ResetBalanceRequest
+		if err := ctx.ShouldBindJSON(&req); err != nil {
+			req = dto.ResetBalanceRequest{}
+		}
+		response, err := service.ResetCardBalance(ctx, cardId, userId, &req)
+		if err != nil {
+			log.Error().Err(err).Str("user_id", userId).Str("card_id", cardId).Msg("Failed to reset card balance")
+			_ = ctx.Error(err)
+			return
+		}
+		ctx.JSON(http.StatusOK, response)
+	}
+}
+
+func FindCardBalanceResets(service *creditcard.CreditCardService) gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		userId := ctx.GetString("X-User-Id")
+		cardId := ctx.Param("id")
+		resets, err := service.FindBalanceResetsByCard(ctx, cardId, userId)
+		if err != nil {
+			_ = ctx.Error(err)
+			return
+		}
+		ctx.JSON(http.StatusOK, resets)
+	}
+}
+
 func CreateCardPayment(service *creditcard.CreditCardService) gin.HandlerFunc {
 	return func(ctx *gin.Context) {
 		userId := ctx.GetString("X-User-Id")

--- a/BackEnd/internal/platform/server/handler/transaction/transactionHandler.go
+++ b/BackEnd/internal/platform/server/handler/transaction/transactionHandler.go
@@ -327,6 +327,7 @@ func UpdateTransaction(s *transaction.TransactionService) gin.HandlerFunc {
 			transactionObj.CreatedAt = transactionRequest.CreatedAt
 		}
 		transactionObj.UserId = userId
+		transactionObj.Currency = transactionRequest.Currency
 
 		if err := s.UpdateTransaction(ctx, id, transactionObj); err != nil {
 			ctx.JSON(http.StatusInternalServerError, err.Error())

--- a/BackEnd/internal/platform/server/routes/creditcardRoutes.go
+++ b/BackEnd/internal/platform/server/routes/creditcardRoutes.go
@@ -21,5 +21,7 @@ func CreditCardRoutes(s *gin.Engine, creditCardService *creditcard.CreditCardSer
 		cardGroup.PUT("/:id/balances/:balanceId", handler.UpdateCardBalance(creditCardService))
 		cardGroup.POST("/:id/payments", handler.CreateCardPayment(creditCardService))
 		cardGroup.GET("/:id/payments", handler.FindCardPayments(creditCardService))
+		cardGroup.POST("/:id/reset", handler.ResetCardBalance(creditCardService))
+		cardGroup.GET("/:id/resets", handler.FindCardBalanceResets(creditCardService))
 	}
 }

--- a/BackEnd/internal/platform/storage/postgress/creditcard/creditcardRepoInterface.go
+++ b/BackEnd/internal/platform/storage/postgress/creditcard/creditcardRepoInterface.go
@@ -22,6 +22,9 @@ type CreditCardRepositoryInterface interface {
 	UpdateBalanceByAmount(ctx context.Context, cardId string, currency string, amount float64) error
 	DeleteBalance(ctx context.Context, id string) error
 
+	SaveBalanceReset(ctx context.Context, reset *creditcard.CardBalanceReset) error
+	FindBalanceResetsByCard(ctx context.Context, cardId string) ([]*creditcard.CardBalanceReset, error)
+
 	SavePayment(ctx context.Context, payment *creditcard.CardPayment) error
 	DeletePayment(ctx context.Context, id string) error
 	FindPaymentById(ctx context.Context, id string) (*creditcard.CardPayment, error)

--- a/BackEnd/internal/platform/storage/postgress/creditcard/creditcardRepository.go
+++ b/BackEnd/internal/platform/storage/postgress/creditcard/creditcardRepository.go
@@ -226,6 +226,44 @@ func (r *CreditCardRepository) UpdateBalanceByAmount(ctx context.Context, cardId
 	return nil
 }
 
+func (r *CreditCardRepository) SaveBalanceReset(ctx context.Context, reset *creditcard.CardBalanceReset) error {
+	query := `INSERT INTO card_balance_resets (id, balance_id, card_id, currency, previous_balance, notes, created_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)`
+	_, err := txhelper.FromContext(ctx, r.db).ExecContext(ctx, query, reset.Id, reset.BalanceId, reset.CardId,
+		reset.Currency, reset.PreviousBalance, reset.Notes, reset.CreatedAt)
+	if err != nil {
+		log.Error().Err(err).Str("card_id", reset.CardId).Str("balance_id", reset.BalanceId).Msg("Failed to save card balance reset")
+	}
+	return err
+}
+
+func (r *CreditCardRepository) FindBalanceResetsByCard(ctx context.Context, cardId string) ([]*creditcard.CardBalanceReset, error) {
+	query := `SELECT id, balance_id, card_id, currency, previous_balance, COALESCE(notes, ''), created_at
+		FROM card_balance_resets WHERE card_id = $1 ORDER BY created_at DESC`
+	rows, err := txhelper.FromContext(ctx, r.db).QueryContext(ctx, query, cardId)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err = rows.Close(); err != nil {
+			log.Error().Err(err).Msg("failed to close database rows")
+		}
+	}()
+
+	var resets []*creditcard.CardBalanceReset
+	for rows.Next() {
+		reset := &creditcard.CardBalanceReset{}
+		if err = rows.Scan(&reset.Id, &reset.BalanceId, &reset.CardId, &reset.Currency,
+			&reset.PreviousBalance, &reset.Notes, &reset.CreatedAt); err == nil {
+			resets = append(resets, reset)
+		}
+	}
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+	return resets, nil
+}
+
 func (r *CreditCardRepository) SavePayment(ctx context.Context, payment *creditcard.CardPayment) error {
 	query := `INSERT INTO card_payments (id, card_id, from_account_id, currency, amount, source_currency, source_amount, exchange_rate, includes_interest, interest_amount, payment_date, status, notes, created_at)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)`

--- a/BackEnd/internal/services/creditcard/creditcardService.go
+++ b/BackEnd/internal/services/creditcard/creditcardService.go
@@ -202,6 +202,74 @@ func (s *CreditCardService) UpdateBalance(ctx context.Context, balanceId string,
 	return dto.NewBalanceResponse(balance), nil
 }
 
+func (s *CreditCardService) ResetCardBalance(ctx context.Context, cardId string, userId string, req *dto.ResetBalanceRequest) (*dto.BalanceResetResponse, error) {
+	if _, err := s.cardRepo.FindCardById(ctx, cardId, userId); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, errors.New("credit card not found")
+		}
+		return nil, err
+	}
+
+	var balance *creditcard.CardBalance
+	var err error
+	if req.BalanceId != "" {
+		balance, err = s.cardRepo.FindBalanceById(ctx, req.BalanceId)
+	} else if req.Currency != "" {
+		balance, err = s.cardRepo.FindBalanceByCardAndCurrency(ctx, cardId, req.Currency)
+	} else {
+		return nil, errors.New("balance_id or currency is required")
+	}
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, errors.New("balance not found")
+		}
+		return nil, err
+	}
+	if balance.CardId != cardId {
+		return nil, errors.New("balance does not belong to this card")
+	}
+
+	previousBalance := balance.CurrentBalance
+
+	resetUuid, _ := ksuid.NewRandom()
+	reset := &creditcard.CardBalanceReset{
+		Id:              resetUuid.String(),
+		BalanceId:       balance.Id,
+		CardId:          cardId,
+		Currency:        balance.Currency,
+		PreviousBalance: previousBalance,
+		Notes:           req.Notes,
+		CreatedAt:       time.Now(),
+	}
+	if err := s.cardRepo.SaveBalanceReset(ctx, reset); err != nil {
+		return nil, err
+	}
+
+	balance.CurrentBalance = 0
+	balance.UpdatedAt = time.Now()
+	if err := s.cardRepo.UpdateBalance(ctx, balance); err != nil {
+		return nil, err
+	}
+
+	log.Info().Str("card_id", cardId).Str("balance_id", balance.Id).Float64("previous_balance", previousBalance).Msg("Card balance reset")
+	return dto.NewBalanceResetResponse(reset), nil
+}
+
+func (s *CreditCardService) FindBalanceResetsByCard(ctx context.Context, cardId string, userId string) ([]*dto.BalanceResetResponse, error) {
+	if _, err := s.cardRepo.FindCardById(ctx, cardId, userId); err != nil {
+		return nil, err
+	}
+	resets, err := s.cardRepo.FindBalanceResetsByCard(ctx, cardId)
+	if err != nil {
+		return nil, err
+	}
+	var responses []*dto.BalanceResetResponse
+	for _, r := range resets {
+		responses = append(responses, dto.NewBalanceResetResponse(r))
+	}
+	return responses, nil
+}
+
 func (s *CreditCardService) CreatePayment(ctx context.Context, cardId string, userId string, req *dto.CreatePaymentRequest) (*dto.PaymentResponse, error) {
 	if err := req.Validate(); err != nil {
 		return nil, err

--- a/BackEnd/internal/services/creditcard/creditcardService_test.go
+++ b/BackEnd/internal/services/creditcard/creditcardService_test.go
@@ -85,6 +85,12 @@ func (m *mockCreditCardRepo) FindPaymentsByCardAndCurrency(context.Context, stri
 func (m *mockCreditCardRepo) GetTotalPaymentsByCardAndCurrency(context.Context, string, string) (float64, error) {
 	return 0, nil
 }
+func (m *mockCreditCardRepo) SaveBalanceReset(context.Context, *creditcardDomain.CardBalanceReset) error {
+	return nil
+}
+func (m *mockCreditCardRepo) FindBalanceResetsByCard(context.Context, string) ([]*creditcardDomain.CardBalanceReset, error) {
+	return nil, nil
+}
 
 type mockAccountRepo struct {
 	account *account.Account

--- a/FrontendNextjs/gestor/app/app/credit-cards/page.tsx
+++ b/FrontendNextjs/gestor/app/app/credit-cards/page.tsx
@@ -25,6 +25,7 @@ import {
 	useDeleteCreditCardMutation,
 	useGetCreditCardSummary,
 	useGetCreditCards,
+	useResetCardBalanceMutation,
 	useUpdateCreditCardMutation,
 } from '@/hooks/queries/useCreditCardsQuery'
 import { useExchangeRateQuery } from '@/hooks/queries/useExchangeRateQuery'
@@ -37,6 +38,7 @@ export default function CreditCardsPage() {
 	const [historyOpen, setHistoryOpen] = useState(false)
 	const [selectedCard, setSelectedCard] = useState<CreditCard | null>(null)
 	const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
+	const [resetDialogOpen, setResetDialogOpen] = useState(false)
 	const router = useRouter()
 
 	const { data: exchangeRateData } = useExchangeRateQuery()
@@ -50,6 +52,7 @@ export default function CreditCardsPage() {
 	const updateMutation = useUpdateCreditCardMutation()
 	const deleteMutation = useDeleteCreditCardMutation()
 	const paymentMutation = useCreatePaymentMutation()
+	const resetBalanceMutation = useResetCardBalanceMutation()
 
 	const handleCreateCard = async (data: CreateCreditCardDTO) => {
 		await createMutation.mutateAsync(data)
@@ -99,6 +102,36 @@ export default function CreditCardsPage() {
 	const handleViewPayments = (card: CreditCard) => {
 		setSelectedCard(card)
 		setHistoryOpen(true)
+	}
+
+	const handleReset = (card: CreditCard) => {
+		setSelectedCard(card)
+		setResetDialogOpen(true)
+	}
+
+	const handleConfirmReset = async () => {
+		if (!selectedCard) return
+		try {
+			const balances = selectedCard.balances || []
+			if (balances.length === 0) {
+				toast.error('No balances to reset')
+				return
+			}
+			await Promise.all(
+				balances.map((balance) =>
+					resetBalanceMutation.mutateAsync({
+						cardId: selectedCard.id,
+						balanceId: balance.id,
+					}),
+				),
+			)
+			toast.success('Card balance reset successfully')
+		} catch {
+			toast.error('Failed to reset card balance')
+		} finally {
+			setResetDialogOpen(false)
+			setSelectedCard(null)
+		}
 	}
 
 	const handleFormClose = () => {
@@ -276,6 +309,7 @@ export default function CreditCardsPage() {
 							onDelete={handleDelete}
 							onPay={handlePay}
 							onViewPayments={handleViewPayments}
+							onReset={handleReset}
 						/>
 					))}
 				</div>
@@ -291,6 +325,26 @@ export default function CreditCardsPage() {
 			<PaymentModal open={paymentOpen} onClose={handlePaymentClose} onSubmit={handlePayment} card={selectedCard} />
 
 			<CreditCardPaymentHistory open={historyOpen} onClose={handleHistoryClose} card={selectedCard} />
+
+			<Dialog open={resetDialogOpen} onOpenChange={setResetDialogOpen}>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>Reset Card Balance</DialogTitle>
+						<DialogDescription>
+							This will set {selectedCard?.name}&apos;s current balance to zero for all currencies. The previous balance
+							will be stored in history. Use this after paying off and closing the billing cycle.
+						</DialogDescription>
+					</DialogHeader>
+					<DialogFooter>
+						<Button variant='outline' onClick={() => setResetDialogOpen(false)}>
+							Cancel
+						</Button>
+						<Button onClick={handleConfirmReset} disabled={resetBalanceMutation.isPending}>
+							{resetBalanceMutation.isPending ? 'Resetting...' : 'Reset Balance'}
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
 
 			<Dialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
 				<DialogContent>

--- a/FrontendNextjs/gestor/app/app/page.tsx
+++ b/FrontendNextjs/gestor/app/app/page.tsx
@@ -15,6 +15,7 @@ import {
 } from 'lucide-react'
 import { getLocale, getTranslations } from 'next-intl/server'
 import { AnimatedTabs } from '@/components/common/animated-tabs'
+import { DashboardDateFilter } from '@/components/dashboard/DashboardDateFilter'
 import { PatrimonyTab } from '@/components/dashboard/PatrimonyTab'
 import { DashboardCharts } from '@/components/transactions/DashboardCharts'
 import { AnimatedCounter } from '@/components/ui/animated-counter'
@@ -263,7 +264,21 @@ function BudgetCard({ budget, category, t }: { budget: Budget; category?: Catego
 }
 
 // Server Component para el header
-function DashboardHeader({ user, t, locale }: { user: any; t: any; locale: string }) {
+function DashboardHeader({
+	user,
+	t,
+	locale,
+	dateFrom,
+	dateTo,
+	preset,
+}: {
+	user: any
+	t: any
+	locale: string
+	dateFrom?: string
+	dateTo?: string
+	preset: 'this_month' | 'last_month' | 'last_3_months' | 'this_year' | 'all' | 'custom'
+}) {
 	return (
 		<div className='mb-8'>
 			<div className='flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4'>
@@ -273,7 +288,8 @@ function DashboardHeader({ user, t, locale }: { user: any; t: any; locale: strin
 						{t('welcome')}, {user?.name} {user?.lastName || user?.last_name} 👋
 					</p>
 				</div>
-				<div className='flex items-center gap-3'>
+				<div className='flex flex-wrap items-center gap-3'>
+					<DashboardDateFilter initialFrom={dateFrom} initialTo={dateTo} initialPreset={preset} />
 					<Badge
 						variant='outline'
 						className='bg-blue-50 dark:bg-blue-900/30 border-blue-200 dark:border-blue-800 text-blue-800 dark:text-blue-400'
@@ -306,8 +322,36 @@ function StatsGrid({ summary, t }: { summary: DashboardSummary | null; t: any })
 	)
 }
 
+type DashboardPreset = 'this_month' | 'last_month' | 'last_3_months' | 'this_year' | 'all' | 'custom'
+
+function resolveDateRange(searchParams: { date_from?: string; date_to?: string; preset?: string }): {
+	dateFrom?: string
+	dateTo?: string
+	preset: DashboardPreset
+} {
+	const presetParam = (searchParams.preset as DashboardPreset) || 'this_month'
+	if (presetParam === 'all') return { preset: 'all' }
+
+	if (searchParams.date_from && searchParams.date_to) {
+		return { dateFrom: searchParams.date_from, dateTo: searchParams.date_to, preset: presetParam }
+	}
+
+	// Default: current month
+	const now = new Date()
+	const from = new Date(now.getFullYear(), now.getMonth(), 1)
+	const to = new Date(now.getFullYear(), now.getMonth() + 1, 0)
+	const fmt = (d: Date) =>
+		`${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+	return { dateFrom: fmt(from), dateTo: fmt(to), preset: 'this_month' }
+}
+
 // Componente principal - Server Component que carga datos directamente
-export default async function DashboardPage() {
+export default async function DashboardPage({
+	searchParams,
+}: {
+	searchParams?: Promise<{ date_from?: string; date_to?: string; preset?: string }>
+}) {
+	const resolvedSearchParams = (await searchParams) ?? {}
 	const accountRepository = await getAccountRepository()
 	const transactionRepository = await getTransactionRepository()
 	const categoryRepository = await getCategoryRepository()
@@ -331,13 +375,17 @@ export default async function DashboardPage() {
 
 	const user = session.user
 
+	const { dateFrom, dateTo, preset } = resolveDateRange(resolvedSearchParams)
+	const transactionFilters = dateFrom && dateTo ? { date_from: dateFrom, date_to: dateTo } : undefined
+	const analyticsFilters = dateFrom && dateTo ? { date_from: dateFrom, date_to: dateTo } : undefined
+
 	const [accounts, transactionResponse, categories, budgets, exchangeRate, dashboardSummary] = await Promise.all([
 		accountRepository.findAll(),
-		transactionRepository.findAllSimple(),
+		transactionRepository.findAllSimple(transactionFilters),
 		categoryRepository.findAll(),
 		budgetRepository.findAll(),
 		exchangeRateRepository.getRate(),
-		analyticsRepository.getDashboardSummary(),
+		analyticsRepository.getDashboardSummary(analyticsFilters),
 	])
 
 	// Extract transactions from the response
@@ -361,7 +409,7 @@ export default async function DashboardPage() {
 		<div className='min-h-screen bg-gradient-to-br from-background via-background to-muted/30 dark:from-background dark:via-background dark:to-muted/20'>
 			<div className='container mx-auto px-4 py-8'>
 				<div id='dashboard-header'>
-					<DashboardHeader user={user} t={t} locale={locale} />
+					<DashboardHeader user={user} t={t} locale={locale} dateFrom={dateFrom} dateTo={dateTo} preset={preset} />
 				</div>
 				<div id='dashboard-charts'>
 					<DashboardCharts

--- a/FrontendNextjs/gestor/app/repository/creditcardRepository.ts
+++ b/FrontendNextjs/gestor/app/repository/creditcardRepository.ts
@@ -46,6 +46,13 @@ export class CreditCardRepository extends BaseRepository {
 	async getPayments(cardId: string): Promise<CardPayment[]> {
 		return this.get<CardPayment[]>(`/credit-cards/${cardId}/payments`) as Promise<CardPayment[]>
 	}
+
+	async resetBalance(
+		cardId: string,
+		data: { balance_id?: string; currency?: string; notes?: string },
+	): Promise<unknown> {
+		return this.post(`/credit-cards/${cardId}/reset`, data)
+	}
 }
 
 let creditCardRepositoryInstance: CreditCardRepository | null = null

--- a/FrontendNextjs/gestor/app/repository/transactionRepository.ts
+++ b/FrontendNextjs/gestor/app/repository/transactionRepository.ts
@@ -64,7 +64,7 @@ export class TransactionRepository extends BaseRepository {
 		}
 	}
 
-	async findAllSimple(): Promise<Transaction[]> {
+	async findAllSimple(filters?: TransactionFilters): Promise<Transaction[]> {
 		try {
 			const allTransactions: Transaction[] = []
 			const pageSize = 100
@@ -74,6 +74,7 @@ export class TransactionRepository extends BaseRepository {
 
 			while (hasNextPage && safetyCounter < 100) {
 				const response = await this.findAll({
+					...filters,
 					page,
 					limit: pageSize,
 					sort_by: 'created_at',

--- a/FrontendNextjs/gestor/components/creditcards/CreditCardItem.tsx
+++ b/FrontendNextjs/gestor/components/creditcards/CreditCardItem.tsx
@@ -15,9 +15,10 @@ interface CreditCardItemProps {
 	onDelete: (card: CreditCard) => void
 	onPay: (card: CreditCard) => void
 	onViewPayments: (card: CreditCard) => void
+	onReset: (card: CreditCard) => void
 }
 
-export function CreditCardItem({ card, onEdit, onDelete, onPay, onViewPayments }: CreditCardItemProps) {
+export function CreditCardItem({ card, onEdit, onDelete, onPay, onViewPayments, onReset }: CreditCardItemProps) {
 	const [isFlipped, setIsFlipped] = useState(false)
 
 	const totalDebtByCurrency = card.balances
@@ -87,6 +88,7 @@ export function CreditCardItem({ card, onEdit, onDelete, onPay, onViewPayments }
 										</DropdownMenuTrigger>
 										<DropdownMenuContent align='end'>
 											<DropdownMenuItem onClick={() => onEdit(card)}>Edit</DropdownMenuItem>
+											<DropdownMenuItem onClick={() => onReset(card)}>Reset Balance</DropdownMenuItem>
 											<DropdownMenuItem onClick={() => onDelete(card)} className='text-destructive'>
 												Delete
 											</DropdownMenuItem>

--- a/FrontendNextjs/gestor/components/creditcards/PaymentModal.tsx
+++ b/FrontendNextjs/gestor/components/creditcards/PaymentModal.tsx
@@ -83,6 +83,12 @@ export function PaymentModal({ open, onClose, onSubmit, card }: PaymentModalProp
 		needsExchangeRate && watchedValues.currency === 'USD' && sourceCurrency === 'DOP' ? rateData?.usd_to_dop : undefined
 
 	useEffect(() => {
+		if (!open || !selectedBalance) return
+		form.setValue('amount', Math.max(0, -selectedBalance.current_balance))
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [watchedValues.currency, open])
+
+	useEffect(() => {
 		if (!needsExchangeRate) {
 			form.setValue('exchangeRate', '')
 			return
@@ -95,19 +101,28 @@ export function PaymentModal({ open, onClose, onSubmit, card }: PaymentModalProp
 
 	const parsedRate = parseFloat(watchedValues.exchangeRate || '0')
 	const exchangeRateValid = !needsExchangeRate || (Number.isFinite(parsedRate) && parsedRate > 0)
+	const paymentAmountNumber = Number(watchedValues.amount)
+	const hasValidAmount = Number.isFinite(paymentAmountNumber) && paymentAmountNumber > 0
 	const debitPreview = (() => {
-		const paymentAmount = watchedValues.amount
-		if (!Number.isFinite(paymentAmount) || paymentAmount <= 0) return 0
-		if (!needsExchangeRate) return paymentAmount
+		if (!hasValidAmount) return 0
+		if (!needsExchangeRate) return paymentAmountNumber
 		if (!exchangeRateValid) return 0
-		if (watchedValues.currency === 'USD' && sourceCurrency === 'DOP') return paymentAmount * parsedRate
-		if (watchedValues.currency === 'DOP' && sourceCurrency === 'USD') return paymentAmount / parsedRate
+		if (watchedValues.currency === 'USD' && sourceCurrency === 'DOP') return paymentAmountNumber * parsedRate
+		if (watchedValues.currency === 'DOP' && sourceCurrency === 'USD') return paymentAmountNumber / parsedRate
 		return 0
 	})()
+	const dopEquivalent = (() => {
+		if (!hasValidAmount) return null
+		if (watchedValues.currency === 'DOP') return paymentAmountNumber
+		const rate = parsedRate > 0 ? parsedRate : rateData?.usd_to_dop
+		if (!rate || rate <= 0) return null
+		return paymentAmountNumber * rate
+	})()
+	const exceedsDebt = hasValidAmount && currentDebt > 0 && paymentAmountNumber > currentDebt
+	const overpayAmount = exceedsDebt ? paymentAmountNumber - currentDebt : 0
 
 	const handleFormSubmit = async (values: PaymentFormValues) => {
 		if (!card) return
-		if (values.amount > currentDebt && currentDebt > 0) return
 
 		const parsedExchangeRate = parseFloat(values.exchangeRate || '0')
 
@@ -196,24 +211,41 @@ export function PaymentModal({ open, onClose, onSubmit, card }: PaymentModalProp
 								<FormItem>
 									<FormLabel>Amount to Pay</FormLabel>
 									<FormControl>
-										<Input
-											type='number'
-											step='0.01'
-											max={currentDebt > 0 ? currentDebt : undefined}
-											placeholder={currentDebt.toString()}
-											{...field}
-										/>
+										<Input type='number' step='0.01' placeholder={currentDebt.toString()} {...field} />
 									</FormControl>
 									<p className='text-xs text-muted-foreground'>
 										Current debt: {currentDebt.toLocaleString()} {watchedValues.currency}
 									</p>
-									{watchedValues.amount > currentDebt && currentDebt > 0 ? (
-										<p className='text-xs text-destructive'>Payment amount cannot exceed current debt.</p>
+									{exceedsDebt ? (
+										<p className='text-xs text-amber-600'>
+											Payment exceeds current debt by{' '}
+											{overpayAmount.toLocaleString(undefined, { maximumFractionDigits: 2 })} {watchedValues.currency}.
+											The extra will be credited to the card.
+										</p>
 									) : null}
 									<FormMessage />
 								</FormItem>
 							)}
 						/>
+
+						{hasValidAmount && (
+							<div className='rounded-md border border-dashed p-3 space-y-1'>
+								<p className='text-xs text-muted-foreground'>
+									Debit from account:{' '}
+									<span className='font-medium text-foreground'>
+										{debitPreview.toLocaleString(undefined, { maximumFractionDigits: 2 })} {sourceCurrency}
+									</span>
+								</p>
+								{watchedValues.currency === 'USD' && dopEquivalent !== null && (
+									<p className='text-xs text-muted-foreground'>
+										Equivalent in DOP:{' '}
+										<span className='font-medium text-foreground'>
+											{dopEquivalent.toLocaleString(undefined, { maximumFractionDigits: 2 })} DOP
+										</span>
+									</p>
+								)}
+							</div>
+						)}
 
 						{needsExchangeRate && (
 							<FormField
@@ -241,10 +273,6 @@ export function PaymentModal({ open, onClose, onSubmit, card }: PaymentModalProp
 												Could not fetch recommended rate. Enter custom rate.
 											</p>
 										)}
-										<p className='text-xs text-muted-foreground'>
-											Estimated debit from account:{' '}
-											{debitPreview.toLocaleString(undefined, { maximumFractionDigits: 2 })} {sourceCurrency}
-										</p>
 										<FormMessage />
 									</FormItem>
 								)}
@@ -295,12 +323,7 @@ export function PaymentModal({ open, onClose, onSubmit, card }: PaymentModalProp
 							</Button>
 							<Button
 								type='submit'
-								disabled={
-									loading ||
-									!watchedValues.fromAccountId ||
-									!exchangeRateValid ||
-									(watchedValues.amount > currentDebt && currentDebt > 0)
-								}
+								disabled={loading || !watchedValues.fromAccountId || !exchangeRateValid || !hasValidAmount}
 							>
 								{loading ? 'Processing…' : 'Make Payment'}
 							</Button>

--- a/FrontendNextjs/gestor/components/dashboard/DashboardDateFilter.tsx
+++ b/FrontendNextjs/gestor/components/dashboard/DashboardDateFilter.tsx
@@ -1,0 +1,125 @@
+'use client'
+
+import { format, parse } from 'date-fns'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useTransition } from 'react'
+import type { DateRange } from 'react-day-picker'
+import { CalendarDateRangePicker } from '@/components/date-range-picker'
+import { Button } from '@/components/ui/button'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+
+type Preset = 'this_month' | 'last_month' | 'last_3_months' | 'this_year' | 'all' | 'custom'
+
+interface Props {
+	initialFrom?: string
+	initialTo?: string
+	initialPreset?: Preset
+}
+
+function computePresetRange(preset: Preset): { from: string; to: string } | null {
+	const now = new Date()
+	const startOfMonth = (d: Date) => new Date(d.getFullYear(), d.getMonth(), 1)
+	const endOfMonth = (d: Date) => new Date(d.getFullYear(), d.getMonth() + 1, 0)
+
+	switch (preset) {
+		case 'this_month':
+			return { from: format(startOfMonth(now), 'yyyy-MM-dd'), to: format(endOfMonth(now), 'yyyy-MM-dd') }
+		case 'last_month': {
+			const prev = new Date(now.getFullYear(), now.getMonth() - 1, 1)
+			return { from: format(startOfMonth(prev), 'yyyy-MM-dd'), to: format(endOfMonth(prev), 'yyyy-MM-dd') }
+		}
+		case 'last_3_months': {
+			const from = new Date(now.getFullYear(), now.getMonth() - 2, 1)
+			return { from: format(from, 'yyyy-MM-dd'), to: format(endOfMonth(now), 'yyyy-MM-dd') }
+		}
+		case 'this_year':
+			return {
+				from: format(new Date(now.getFullYear(), 0, 1), 'yyyy-MM-dd'),
+				to: format(new Date(now.getFullYear(), 11, 31), 'yyyy-MM-dd'),
+			}
+		case 'all':
+		case 'custom':
+		default:
+			return null
+	}
+}
+
+export function DashboardDateFilter({ initialFrom, initialTo, initialPreset = 'this_month' }: Props) {
+	const router = useRouter()
+	const searchParams = useSearchParams()
+	const [isPending, startTransition] = useTransition()
+
+	const pushFilter = (next: { from?: string; to?: string; preset: Preset }) => {
+		const params = new URLSearchParams(searchParams?.toString())
+		if (next.from) params.set('date_from', next.from)
+		else params.delete('date_from')
+		if (next.to) params.set('date_to', next.to)
+		else params.delete('date_to')
+		params.set('preset', next.preset)
+		startTransition(() => {
+			router.replace(`?${params.toString()}`, { scroll: false })
+		})
+	}
+
+	const handlePresetChange = (preset: Preset) => {
+		if (preset === 'all') {
+			pushFilter({ preset })
+			return
+		}
+		if (preset === 'custom') {
+			pushFilter({ from: initialFrom, to: initialTo, preset })
+			return
+		}
+		const range = computePresetRange(preset)
+		if (range) pushFilter({ from: range.from, to: range.to, preset })
+	}
+
+	const handleCustomRange = (range: DateRange | undefined) => {
+		if (!range?.from) return
+		const from = format(range.from, 'yyyy-MM-dd')
+		const to = range.to ? format(range.to, 'yyyy-MM-dd') : from
+		pushFilter({ from, to, preset: 'custom' })
+	}
+
+	const pickerValue: DateRange | undefined =
+		initialFrom && initialTo
+			? {
+					from: parse(initialFrom, 'yyyy-MM-dd', new Date()),
+					to: parse(initialTo, 'yyyy-MM-dd', new Date()),
+				}
+			: undefined
+
+	const clearFilter = () => {
+		const params = new URLSearchParams(searchParams?.toString())
+		params.delete('date_from')
+		params.delete('date_to')
+		params.delete('preset')
+		startTransition(() => {
+			router.replace(`?${params.toString()}`, { scroll: false })
+		})
+	}
+
+	return (
+		<div className='flex flex-wrap items-center gap-2' data-loading={isPending ? 'true' : 'false'}>
+			<Select value={initialPreset} onValueChange={(v) => handlePresetChange(v as Preset)}>
+				<SelectTrigger className='w-[180px]'>
+					<SelectValue />
+				</SelectTrigger>
+				<SelectContent>
+					<SelectItem value='this_month'>This month</SelectItem>
+					<SelectItem value='last_month'>Last month</SelectItem>
+					<SelectItem value='last_3_months'>Last 3 months</SelectItem>
+					<SelectItem value='this_year'>This year</SelectItem>
+					<SelectItem value='all'>All time</SelectItem>
+					<SelectItem value='custom'>Custom range</SelectItem>
+				</SelectContent>
+			</Select>
+			{initialPreset === 'custom' && <CalendarDateRangePicker value={pickerValue} onChange={handleCustomRange} />}
+			{initialPreset !== 'this_month' && (
+				<Button variant='ghost' size='sm' onClick={clearFilter}>
+					Reset
+				</Button>
+			)}
+		</div>
+	)
+}

--- a/FrontendNextjs/gestor/components/date-range-picker.tsx
+++ b/FrontendNextjs/gestor/components/date-range-picker.tsx
@@ -14,7 +14,7 @@ export function CalendarDateRangePicker({
 	className,
 	value,
 	onChange,
-}: React.HTMLAttributes<HTMLDivElement> & {
+}: Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange'> & {
 	value?: DateRange | undefined
 	onChange?: (_range: DateRange | undefined) => void
 }) {

--- a/FrontendNextjs/gestor/hooks/queries/useCreditCardsQuery.ts
+++ b/FrontendNextjs/gestor/hooks/queries/useCreditCardsQuery.ts
@@ -98,6 +98,32 @@ export function useDeleteCreditCardMutation() {
 	})
 }
 
+export function useResetCardBalanceMutation() {
+	const queryClient = useQueryClient()
+
+	return useMutation({
+		mutationFn: async ({
+			cardId,
+			balanceId,
+			currency,
+			notes,
+		}: {
+			cardId: string
+			balanceId?: string
+			currency?: string
+			notes?: string
+		}) => {
+			const repo = await getCreditCardRepository()
+			return repo.resetBalance(cardId, { balance_id: balanceId, currency, notes })
+		},
+		onSuccess: (_, variables) => {
+			queryClient.invalidateQueries({ queryKey: CREDIT_CARD_KEYS.lists() })
+			queryClient.invalidateQueries({ queryKey: CREDIT_CARD_KEYS.summary() })
+			queryClient.invalidateQueries({ queryKey: CREDIT_CARD_KEYS.detail(variables.cardId) })
+		},
+	})
+}
+
 export function useCreatePaymentMutation() {
 	const queryClient = useQueryClient()
 

--- a/FrontendNextjs/gestor/tests/components/creditcards/PaymentModal.test.tsx
+++ b/FrontendNextjs/gestor/tests/components/creditcards/PaymentModal.test.tsx
@@ -131,7 +131,7 @@ describe('PaymentModal', () => {
 		expect(submitButton).toBeDisabled()
 	})
 
-	it('shows error when amount > current debt', async () => {
+	it('shows advisory when amount exceeds current debt but does not block submit', async () => {
 		const user = userEvent.setup()
 		renderModal()
 
@@ -144,7 +144,7 @@ describe('PaymentModal', () => {
 		await user.type(amountInput, '20000')
 
 		await waitFor(() => {
-			expect(screen.getByText('Payment amount cannot exceed current debt.')).toBeInTheDocument()
+			expect(screen.getByText(/Payment exceeds current debt by/i)).toBeInTheDocument()
 		})
 	})
 


### PR DESCRIPTION
## Summary

Batch PR with five related issues resolved in a single branch.

### MYP-45 — Flexible credit card payment + DOP preview
- Reset amount when currency changes so switching balances doesn't trip the "exceeds debt" error.
- Removed the blocking `amount > currentDebt` check; replaced with an amber advisory showing the overpay delta. Overpay is now allowed (credited to the card).
- Always renders a debit preview block; when paying in USD it also shows the equivalent in DOP using the entered rate (or the recommended API rate as fallback).

### MYP-44 — Credit card balance reset with history
- New migration `000041_create_card_balance_resets` (RLS policy matching existing credit card tables).
- `CardBalanceReset` domain, repository, service (`ResetCardBalance`, `FindBalanceResetsByCard`), handlers and routes (`POST /credit-cards/:id/reset`, `GET /credit-cards/:id/resets`).
- Frontend: `useResetCardBalanceMutation`, "Reset Balance" action in the card dropdown, confirmation dialog that resets every currency balance in parallel on confirm.

### MYP-41 — Currency not persisted when editing a transaction
- `UpdateTransaction` handler was building the domain object without copying `Currency` from the DTO, so switching DOP ↔ USD was silently dropped. One-line fix.

### MYP-42 — Date range filter in the dashboard
- New `DashboardDateFilter` client component with presets (this month / last month / last 3 months / this year / all time / custom) and a custom range picker.
- Filter state lives in the URL (`date_from`, `date_to`, `preset`) so the server component re-renders with filtered data. Default is current month.
- `findAllSimple` now forwards `TransactionFilters`; `DashboardPage` forwards the range to the analytics and transaction queries.
- Patrimony tab is unaffected — backend computes patrimonial totals independently of the date range.
- Fix: `CalendarDateRangePicker`'s `onChange` prop now omits the colliding `HTMLAttributes.onChange` so the wrapper typechecks.

### MYP-46 — Expanded MCP server (+17 tools)
Wires `CreditCard` and `Loan` services into the MCP `Services` struct and adds new tools in `tools.go` / `tools_extra.go`:

- **Transactions:** `list_transactions` now accepts `date_from`, `date_to`, `account_id`, `category_id`, `type`; new `update_transaction` and `delete_transaction`.
- **Accounts:** `create_account`, `update_account`, `delete_account`.
- **Categories:** `create_category`, `update_category`, `delete_category`.
- **Analytics:** `balance_by_period` (preset or custom range), `financial_summary` (current vs previous month with % change).
- **Credit cards:** `list_credit_cards`, `credit_card_summary`, `pay_credit_card`, `reset_credit_card_balance`.
- **Loans:** `list_loans`, `get_loan`, `create_loan`, `register_loan_payment`, `loan_summary`.

`runRW` / `runRO` helpers encapsulate the `withRLSTx + commit/rollback` pattern to keep handlers concise. Every handler authenticates from context and runs under an RLS-scoped transaction.

## Test plan

- [x] `cd BackEnd && make lint` — 0 issues
- [x] `cd BackEnd && go build ./...`
- [x] `cd BackEnd && go test ./internal/services/creditcard/... ./internal/platform/mcp/...`
- [x] `cd FrontendNextjs/gestor && npm test` — 198/198 passing
- [x] `cd FrontendNextjs/gestor && npx tsc --noEmit`
- [ ] Manual: run `make migrate` to apply `000041_create_card_balance_resets`.
- [ ] Manual QA: pay a DOP card, pay a USD card (verify preview shows DOP equivalent), overpay a card (verify advisory).
- [ ] Manual QA: reset a card with balances in multiple currencies, check `card_balance_resets` history row.
- [ ] Manual QA: edit a transaction and change its currency DOP ↔ USD, verify it persists.
- [ ] Manual QA: dashboard — switch between presets and a custom range, verify stats/charts update and patrimony tab stays constant.
- [ ] Manual QA: call each new MCP tool from Claude (at minimum: `list_transactions` with filters, `update_transaction`, `balance_by_period`, `financial_summary`, `pay_credit_card`, `reset_credit_card_balance`, `create_loan`, `register_loan_payment`).